### PR TITLE
Feature/soo step2

### DIFF
--- a/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
+++ b/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
@@ -1,7 +1,7 @@
 package org.c4marathon.assignment.account.controller;
 
 import org.c4marathon.assignment.account.dto.request.RechargeAccountRequestDto;
-import org.c4marathon.assignment.account.dto.request.TransferToSavingAccountRequestDto;
+import org.c4marathon.assignment.account.dto.request.TransferToOtherAccountRequestDto;
 import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
 import org.c4marathon.assignment.account.service.AccountService;
 import org.springframework.http.HttpStatus;
@@ -49,8 +49,19 @@ public class AccountController {
     public void rechargeAccount(
         @Valid
         @RequestBody
-        TransferToSavingAccountRequestDto transferToSavingAccountRequestDto
+        TransferToOtherAccountRequestDto transferToOtherAccountRequestDto
     ) {
-        accountService.transferFromRegularAccount(transferToSavingAccountRequestDto);
+        accountService.transferFromRegularAccount(transferToOtherAccountRequestDto);
+    }
+
+    @Operation(summary = "사용자의 메인 계좌에서 친구의 메인 계좌로 송금")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PostMapping("/transfer")
+    public void transferToOtherAccount(
+        @Valid
+        @RequestBody
+        TransferToOtherAccountRequestDto transferToOtherAccountRequestDto
+    ) {
+        accountService.transferToOtherAccount(transferToOtherAccountRequestDto);
     }
 }

--- a/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
+++ b/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
@@ -32,7 +32,7 @@ public class AccountController {
 
     @Operation(summary = "메인 계좌 충전")
     @PostMapping("/recharge")
-    public ResponseEntity rechargeAccount(
+    public ResponseEntity<Void> rechargeAccount(
         @Valid
         @RequestBody
         RechargeAccountRequestDto rechargeAccountRequestDto
@@ -43,7 +43,7 @@ public class AccountController {
 
     @Operation(summary = "메인 계좌에서 적금 계좌로 이체")
     @PostMapping("/transfer/saving")
-    public ResponseEntity rechargeAccount(
+    public ResponseEntity<Void> rechargeAccount(
         @Valid
         @RequestBody
         TransferToOtherAccountRequestDto transferToOtherAccountRequestDto
@@ -54,7 +54,7 @@ public class AccountController {
 
     @Operation(summary = "사용자의 메인 계좌에서 친구의 메인 계좌로 송금")
     @PostMapping("/transfer/regular")
-    public ResponseEntity transferToOtherAccount(
+    public ResponseEntity<Void> transferToOtherAccount(
         @Valid
         @RequestBody
         TransferToOtherAccountRequestDto transferToOtherAccountRequestDto

--- a/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
+++ b/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
@@ -1,10 +1,7 @@
 package org.c4marathon.assignment.account.controller;
 
-import java.util.List;
-
-import org.c4marathon.assignment.account.dto.request.AccountRequestDto;
 import org.c4marathon.assignment.account.dto.request.RechargeAccountRequestDto;
-import org.c4marathon.assignment.account.dto.request.SavingAccountRequestDto;
+import org.c4marathon.assignment.account.dto.request.TransferToSavingAccountRequestDto;
 import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
 import org.c4marathon.assignment.account.service.AccountService;
 import org.springframework.http.HttpStatus;
@@ -27,25 +24,12 @@ public class AccountController {
 
     private final AccountService accountService;
 
-    @Operation(summary = "추가 계좌 생성")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    @PostMapping("")
-    public void createAccount(
-        @Valid
-        @RequestBody
-        AccountRequestDto accountRequestDto
-    ) {
-
-        accountService.saveAccount(accountRequestDto);
-    }
-
-    @Operation(summary = "계좌 전체 조회")
+    @Operation(summary = "메인 계좌 조회")
     @GetMapping("")
-    public ResponseEntity<List<AccountResponseDto>> findAccount(
+    public ResponseEntity<AccountResponseDto> findAccount(
     ) {
-
-        List<AccountResponseDto> accountResponseDtoList = accountService.findAccount();
-        return ResponseEntity.ok(accountResponseDtoList);
+        AccountResponseDto accountResponseDto = accountService.findAccount();
+        return ResponseEntity.ok(accountResponseDto);
     }
 
     @Operation(summary = "메인 계좌 충전")
@@ -65,8 +49,8 @@ public class AccountController {
     public void rechargeAccount(
         @Valid
         @RequestBody
-        SavingAccountRequestDto savingAccountRequestDto
+        TransferToSavingAccountRequestDto transferToSavingAccountRequestDto
     ) {
-        accountService.transferFromRegularAccount(savingAccountRequestDto);
+        accountService.transferFromRegularAccount(transferToSavingAccountRequestDto);
     }
 }

--- a/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
+++ b/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
@@ -33,35 +33,35 @@ public class AccountController {
     }
 
     @Operation(summary = "메인 계좌 충전")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PostMapping("/recharge")
-    public void rechargeAccount(
+    public ResponseEntity rechargeAccount(
         @Valid
         @RequestBody
         RechargeAccountRequestDto rechargeAccountRequestDto
     ) {
         accountService.rechargeAccount(rechargeAccountRequestDto);
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "메인 계좌에서 적금 계좌로 이체")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    @PostMapping("/saving")
-    public void rechargeAccount(
+    @PostMapping("/transfer/saving")
+    public ResponseEntity rechargeAccount(
         @Valid
         @RequestBody
         TransferToOtherAccountRequestDto transferToOtherAccountRequestDto
     ) {
         accountService.transferFromRegularAccount(transferToOtherAccountRequestDto);
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "사용자의 메인 계좌에서 친구의 메인 계좌로 송금")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    @PostMapping("/transfer")
-    public void transferToOtherAccount(
+    @PostMapping("/transfer/regular")
+    public ResponseEntity transferToOtherAccount(
         @Valid
         @RequestBody
         TransferToOtherAccountRequestDto transferToOtherAccountRequestDto
     ) {
         accountService.transferToOtherAccount(transferToOtherAccountRequestDto);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
+++ b/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
@@ -4,13 +4,11 @@ import org.c4marathon.assignment.account.dto.request.RechargeAccountRequestDto;
 import org.c4marathon.assignment.account.dto.request.TransferToOtherAccountRequestDto;
 import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
 import org.c4marathon.assignment.account.service.AccountService;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/org/c4marathon/assignment/account/controller/SavingAccountController.java
+++ b/src/main/java/org/c4marathon/assignment/account/controller/SavingAccountController.java
@@ -1,0 +1,46 @@
+package org.c4marathon.assignment.account.controller;
+
+import java.util.List;
+
+import org.c4marathon.assignment.account.dto.request.AccountRequestDto;
+import org.c4marathon.assignment.account.dto.response.SavingAccountResponseDto;
+import org.c4marathon.assignment.account.service.SavingAccountService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/accounts/saving")
+public class SavingAccountController {
+
+    private final SavingAccountService savingAccountService;
+
+    @Operation(summary = "적금 계좌 생성")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PostMapping("")
+    public void createAccount(
+        @Valid
+        @RequestBody
+        AccountRequestDto accountRequestDto
+    ) {
+        savingAccountService.saveSavingAccount(accountRequestDto);
+    }
+
+    @Operation(summary = "적금 계좌 조회")
+    @GetMapping("")
+    public ResponseEntity<List<SavingAccountResponseDto>> findSavingAccount(
+    ) {
+        List<SavingAccountResponseDto> savingAccountResponseDtoList = savingAccountService.findSavingAccount();
+        return ResponseEntity.ok(savingAccountResponseDtoList);
+    }
+}

--- a/src/main/java/org/c4marathon/assignment/account/controller/SavingAccountController.java
+++ b/src/main/java/org/c4marathon/assignment/account/controller/SavingAccountController.java
@@ -5,13 +5,11 @@ import java.util.List;
 import org.c4marathon.assignment.account.dto.request.AccountRequestDto;
 import org.c4marathon.assignment.account.dto.response.SavingAccountResponseDto;
 import org.c4marathon.assignment.account.service.SavingAccountService;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,20 +18,20 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/accounts/savings")
+@RequestMapping("/accounts/saving")
 public class SavingAccountController {
 
     private final SavingAccountService savingAccountService;
 
     @Operation(summary = "적금 계좌 생성")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PostMapping("")
-    public void createAccount(
+    public ResponseEntity createAccount(
         @Valid
         @RequestBody
         AccountRequestDto accountRequestDto
     ) {
         savingAccountService.saveSavingAccount(accountRequestDto);
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "적금 계좌 조회")

--- a/src/main/java/org/c4marathon/assignment/account/controller/SavingAccountController.java
+++ b/src/main/java/org/c4marathon/assignment/account/controller/SavingAccountController.java
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/accounts/saving")
+@RequestMapping("/accounts/savings")
 public class SavingAccountController {
 
     private final SavingAccountService savingAccountService;

--- a/src/main/java/org/c4marathon/assignment/account/controller/SavingAccountController.java
+++ b/src/main/java/org/c4marathon/assignment/account/controller/SavingAccountController.java
@@ -25,7 +25,7 @@ public class SavingAccountController {
 
     @Operation(summary = "적금 계좌 생성")
     @PostMapping("")
-    public ResponseEntity createAccount(
+    public ResponseEntity<Void> createAccount(
         @Valid
         @RequestBody
         AccountRequestDto accountRequestDto

--- a/src/main/java/org/c4marathon/assignment/account/dto/request/AccountRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/request/AccountRequestDto.java
@@ -1,11 +1,13 @@
 package org.c4marathon.assignment.account.dto.request;
 
 import org.c4marathon.assignment.account.entity.Type;
+import org.c4marathon.assignment.account.validation.ValidType;
 
 import jakarta.validation.constraints.NotNull;
 
 public record AccountRequestDto(
     @NotNull
+    @ValidType
     Type type
 ) {
 }

--- a/src/main/java/org/c4marathon/assignment/account/dto/request/RechargeAccountRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/request/RechargeAccountRequestDto.java
@@ -1,11 +1,12 @@
 package org.c4marathon.assignment.account.dto.request;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 
 public record RechargeAccountRequestDto(
     @NotNull
     Long accountId,
-    @NotNull
+    @PositiveOrZero
     Long balance
 ) {
 }

--- a/src/main/java/org/c4marathon/assignment/account/dto/request/TransferToOtherAccountRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/request/TransferToOtherAccountRequestDto.java
@@ -1,11 +1,11 @@
 package org.c4marathon.assignment.account.dto.request;
 
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 
 public record TransferToOtherAccountRequestDto(
 
-    @NotNull
+    @PositiveOrZero
     Long balance,
     @NotNull
     Long receiverAccountId

--- a/src/main/java/org/c4marathon/assignment/account/dto/request/TransferToOtherAccountRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/request/TransferToOtherAccountRequestDto.java
@@ -1,8 +1,10 @@
 package org.c4marathon.assignment.account.dto.request;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
-public record TransferToSavingAccountRequestDto(
+public record TransferToOtherAccountRequestDto(
+
     @NotNull
     Long balance,
     @NotNull

--- a/src/main/java/org/c4marathon/assignment/account/dto/request/TransferToSavingAccountRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/request/TransferToSavingAccountRequestDto.java
@@ -2,7 +2,7 @@ package org.c4marathon.assignment.account.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 
-public record SavingAccountRequestDto(
+public record TransferToSavingAccountRequestDto(
     @NotNull
     Long balance,
     @NotNull

--- a/src/main/java/org/c4marathon/assignment/account/dto/response/AccountResponseDto.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/response/AccountResponseDto.java
@@ -3,8 +3,11 @@ package org.c4marathon.assignment.account.dto.response;
 import org.c4marathon.assignment.account.entity.Account;
 import org.c4marathon.assignment.account.entity.Type;
 
+import jakarta.validation.constraints.PositiveOrZero;
+
 public record AccountResponseDto(
     Long id,
+    @PositiveOrZero
     Long balance,
     Integer dailyLimit,
     Type type

--- a/src/main/java/org/c4marathon/assignment/account/dto/response/SavingAccountResponseDto.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/response/SavingAccountResponseDto.java
@@ -3,8 +3,11 @@ package org.c4marathon.assignment.account.dto.response;
 import org.c4marathon.assignment.account.entity.SavingAccount;
 import org.c4marathon.assignment.account.entity.Type;
 
+import jakarta.validation.constraints.PositiveOrZero;
+
 public record SavingAccountResponseDto(
     Long id,
+    @PositiveOrZero
     Long balance,
     Type type
 ) {

--- a/src/main/java/org/c4marathon/assignment/account/dto/response/SavingAccountResponseDto.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/response/SavingAccountResponseDto.java
@@ -1,0 +1,19 @@
+package org.c4marathon.assignment.account.dto.response;
+
+import org.c4marathon.assignment.account.entity.SavingAccount;
+import org.c4marathon.assignment.account.entity.Type;
+
+public record SavingAccountResponseDto(
+    Long id,
+    Long balance,
+    Type type
+) {
+
+    public static SavingAccountResponseDto entityToDto(SavingAccount savingAccount) {
+        return new SavingAccountResponseDto(
+            savingAccount.getId(),
+            savingAccount.getBalance(),
+            savingAccount.getType()
+        );
+    }
+}

--- a/src/main/java/org/c4marathon/assignment/account/entity/Account.java
+++ b/src/main/java/org/c4marathon/assignment/account/entity/Account.java
@@ -25,7 +25,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 @Entity
-@Table(name = "account", indexes = @Index(name = "idx_member_id", columnList = "member_id"))
+@Table(name = "account", indexes = @Index(name = "idx_account_member_id", columnList = "member_id"))
 public class Account extends BaseEntity {
 
     @Id

--- a/src/main/java/org/c4marathon/assignment/account/entity/Account.java
+++ b/src/main/java/org/c4marathon/assignment/account/entity/Account.java
@@ -1,5 +1,8 @@
 package org.c4marathon.assignment.account.entity;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+
 import org.c4marathon.assignment.member.entity.Member;
 import org.c4marathon.assignment.util.entity.BaseEntity;
 
@@ -39,6 +42,9 @@ public class Account extends BaseEntity {
     @Column(name = "daily_limit", nullable = false)
     private Integer dailyLimit;
 
+    @Column(name = "daily_limit_update_at", nullable = false)
+    private LocalDate dailyLimitUpdateAt;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false)
     private Type type;
@@ -54,10 +60,12 @@ public class Account extends BaseEntity {
         this.dailyLimit = 0;
         this.type = type;
         this.member = member;
+        this.dailyLimitUpdateAt = LocalDate.now(ZoneId.of("Asia/Seoul"));
     }
 
     public void resetDailyLimit(Integer dailyLimit) {
         this.dailyLimit = dailyLimit;
+        this.dailyLimitUpdateAt = LocalDate.now(ZoneId.of("Asia/Seoul"));
     }
 
     public void transferBalance(Long balance) {

--- a/src/main/java/org/c4marathon/assignment/account/entity/SavingAccount.java
+++ b/src/main/java/org/c4marathon/assignment/account/entity/SavingAccount.java
@@ -1,0 +1,57 @@
+package org.c4marathon.assignment.account.entity;
+
+import org.c4marathon.assignment.member.entity.Member;
+import org.c4marathon.assignment.util.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Entity
+@Table(name = "saving_account", indexes = @Index(name = "idx_member_id", columnList = "member_id"))
+public class SavingAccount extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Long id;
+
+    @Column(name = "balance", nullable = false)
+    private Long balance;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private Type type;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Builder
+    public SavingAccount(Type type, Member member) {
+
+        this.balance = 0L;
+        this.type = type;
+        this.member = member;
+    }
+
+    public void transferBalance(Long balance) {
+        this.balance = balance;
+    }
+}

--- a/src/main/java/org/c4marathon/assignment/account/entity/SavingAccount.java
+++ b/src/main/java/org/c4marathon/assignment/account/entity/SavingAccount.java
@@ -25,7 +25,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 @Entity
-@Table(name = "saving_account", indexes = @Index(name = "idx_member_id", columnList = "member_id"))
+@Table(name = "saving_account", indexes = @Index(name = "idx_saving_account_member_id", columnList = "member_id"))
 public class SavingAccount extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/c4marathon/assignment/account/entity/Type.java
+++ b/src/main/java/org/c4marathon/assignment/account/entity/Type.java
@@ -4,7 +4,6 @@ public enum Type {
 
     // 송금 계좌
     REGULAR_ACCOUNT, // 일반 계좌
-    ADDITIONAL_ACCOUNT, // 추가 계좌
 
     // 적금 계좌
     INSTALLMENT_SAVINGS_ACCOUNT, // 정기 적금 계좌

--- a/src/main/java/org/c4marathon/assignment/account/repository/AccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/account/repository/AccountRepository.java
@@ -20,11 +20,7 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
 
     // 회원의 메인 계좌 조회
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("""
-        SELECT a FROM Account a
-        WHERE a.member.id = :memberId
-        """)
-    Optional<Account> findByAccount(Long memberId);
+    Optional<Account> findAccountByMemberId(Long memberId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("""

--- a/src/main/java/org/c4marathon/assignment/account/repository/AccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/account/repository/AccountRepository.java
@@ -36,5 +36,5 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
             UPDATE Account a SET a.balance = a.balance - :balance
             WHERE a.member.id = :memberId AND a.type = :type AND a.balance >= :balance
         """)
-    void transferAccount(Long memberId, Long balance, Type type);
+    int transferAccount(Long memberId, Long balance, Type type);
 }

--- a/src/main/java/org/c4marathon/assignment/account/repository/AccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/account/repository/AccountRepository.java
@@ -23,7 +23,13 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
     @Query("""
         SELECT a FROM Account a
         WHERE a.member.id = :memberId
-        AND a.type = 'REGULAR_ACCOUNT'
         """)
-    Optional<Account> findByRegularAccount(Long memberId);
+    Optional<Account> findByAccount(Long memberId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        SELECT a FROM Account a
+        WHERE a.id = :accountId
+        """)
+    Optional<Account> findByOtherAccount(Long accountId);
 }

--- a/src/main/java/org/c4marathon/assignment/account/repository/AccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/account/repository/AccountRepository.java
@@ -13,19 +13,10 @@ import jakarta.persistence.LockModeType;
 
 public interface AccountRepository extends JpaRepository<Account, Long> {
     // 회원의 전체 계좌 조회
-    List<Account> findByMemberId(Long memberId);
+    Account findByMemberId(Long memberId);
 
     // 회원의 메인 계좌가 존재하는지 확인
     boolean existsAccountByMemberIdAndType(Long memberId, Type type);
-
-    // 회원의 특정 계좌 조회
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("""
-        SELECT a FROM Account a
-        WHERE a.member.id = :memberId
-        AND a.id = :id
-        """)
-    Optional<Account> findByAccount(Long memberId, Long id);
 
     // 회원의 메인 계좌 조회
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/org/c4marathon/assignment/account/repository/AccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/account/repository/AccountRepository.java
@@ -1,12 +1,12 @@
 package org.c4marathon.assignment.account.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.c4marathon.assignment.account.entity.Account;
 import org.c4marathon.assignment.account.entity.Type;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import jakarta.persistence.LockModeType;
@@ -20,12 +20,21 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
 
     // 회원의 메인 계좌 조회
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    Optional<Account> findAccountByMemberId(Long memberId);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("""
         SELECT a FROM Account a
-        WHERE a.id = :accountId
+        WHERE a.member.id = :memberId AND a.type = :type
         """)
-    Optional<Account> findByOtherAccount(Long accountId);
+    Optional<Account> findAccountByMemberId(Long memberId, Type type);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<Account> findAccountById(Long accountId);
+
+    boolean existsAccountById(Long id);
+
+    @Modifying
+    @Query("""
+            UPDATE Account a SET a.balance = a.balance - :balance
+            WHERE a.member.id = :memberId AND a.type = :type AND a.balance >= :balance
+        """)
+    void transferAccount(Long memberId, Long balance, Type type);
 }

--- a/src/main/java/org/c4marathon/assignment/account/repository/SavingAccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/account/repository/SavingAccountRepository.java
@@ -28,6 +28,6 @@ public interface SavingAccountRepository extends JpaRepository<SavingAccount, Lo
     @Query("""
         UPDATE SavingAccount sa SET sa.balance = sa.balance + :balance
         WHERE sa.id = :id
-    """)
+        """)
     void transferSavingAccount(Long id, Long balance);
 }

--- a/src/main/java/org/c4marathon/assignment/account/repository/SavingAccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/account/repository/SavingAccountRepository.java
@@ -3,10 +3,10 @@ package org.c4marathon.assignment.account.repository;
 import java.util.List;
 import java.util.Optional;
 
-import org.c4marathon.assignment.account.entity.Account;
 import org.c4marathon.assignment.account.entity.SavingAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import jakarta.persistence.LockModeType;
@@ -23,4 +23,11 @@ public interface SavingAccountRepository extends JpaRepository<SavingAccount, Lo
         AND sa.id = :id
         """)
     Optional<SavingAccount> findBySavingAccount(Long memberId, Long id);
+
+    @Modifying
+    @Query("""
+        UPDATE SavingAccount sa SET sa.balance = sa.balance + :balance
+        WHERE sa.id = :id
+    """)
+    void transferSavingAccount(Long id, Long balance);
 }

--- a/src/main/java/org/c4marathon/assignment/account/repository/SavingAccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/account/repository/SavingAccountRepository.java
@@ -1,0 +1,26 @@
+package org.c4marathon.assignment.account.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.c4marathon.assignment.account.entity.Account;
+import org.c4marathon.assignment.account.entity.SavingAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import jakarta.persistence.LockModeType;
+
+public interface SavingAccountRepository extends JpaRepository<SavingAccount, Long>  {
+
+    List<SavingAccount> findByMemberId(Long memberId);
+
+    // 회원의 적금 계좌 조회
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        SELECT sa FROM SavingAccount sa
+        WHERE sa.member.id = :memberId
+        AND sa.id = :id
+        """)
+    Optional<SavingAccount> findBySavingAccount(Long memberId, Long id);
+}

--- a/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
@@ -133,7 +133,7 @@ public class AccountService {
         Long memberId = securityService.findMember();
 
         Account account = accountRepository.findByAccount(memberId).orElseThrow(
-            () -> new BaseException(ErrorCode.REGULAR_ACCOUNT_DOES_NOT_EXIST.toString(), FORBIDDEN.toString()));
+            () -> new BaseException(ErrorCode.ACCOUNT_DOES_NOT_EXIST.toString(), FORBIDDEN.toString()));
 
         // 계좌 잔액이 부족할 때 충전 메서드 호출
         // 부족한 금액을 만원 단위로 충전

--- a/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
@@ -11,6 +11,7 @@ import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
 import org.c4marathon.assignment.account.entity.Account;
 import org.c4marathon.assignment.account.entity.Type;
 import org.c4marathon.assignment.account.repository.AccountRepository;
+import org.c4marathon.assignment.auth.service.SecurityService;
 import org.c4marathon.assignment.member.entity.Member;
 import org.c4marathon.assignment.member.service.MemberService;
 import org.c4marathon.assignment.util.exceptions.BaseException;
@@ -31,14 +32,9 @@ public class AccountService {
 
     private final MemberService memberService;
 
+    private final SecurityService securityService;
+
     public static final int DAILY_LIMIT = 3_000_000;
-
-    public Long findMember() {
-
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        return (Long)authentication.getPrincipal();
-    }
 
     // 회원 가입 시 메인 계좌 생성
     @Transactional(isolation = Isolation.READ_COMMITTED)
@@ -54,7 +50,7 @@ public class AccountService {
     @Transactional(isolation = Isolation.READ_COMMITTED)
     public void saveAccount(AccountRequestDto accountRequestDto) {
 
-        Long memberId = findMember();
+        Long memberId = securityService.findMember();
         Member member = memberService.getMemberById(memberId);
         Account account = createAccount(accountRequestDto.type(), member);
 
@@ -84,7 +80,7 @@ public class AccountService {
     public List<AccountResponseDto> findAccount() {
 
         // 회원 정보 조회
-        Long memberId = findMember();
+        Long memberId = securityService.findMember();
         List<Account> accountList = accountRepository.findByMemberId(memberId);
 
         // 계좌 조회 후 Entity를 Dto로 변환 후 리턴
@@ -98,7 +94,7 @@ public class AccountService {
     public void rechargeAccount(RechargeAccountRequestDto rechargeAccountRequestDto) {
 
         // 회원 정보 조회
-        Long memberId = findMember();
+        Long memberId = securityService.findMember();
 
         // 계좌 정보 조회
         Account account = accountRepository.findByRegularAccount(memberId)
@@ -125,7 +121,7 @@ public class AccountService {
     public void transferFromRegularAccount(SavingAccountRequestDto savingAccountRequestDto) {
 
         // 회원 정보 조회
-        Long memberId = findMember();
+        Long memberId = securityService.findMember();
 
         // 메인 계좌 및 적금 계좌 조회
         Account regularAccount = accountRepository.findByRegularAccount(memberId)

--- a/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
@@ -3,7 +3,7 @@ package org.c4marathon.assignment.account.service;
 import static org.springframework.http.HttpStatus.*;
 
 import org.c4marathon.assignment.account.dto.request.RechargeAccountRequestDto;
-import org.c4marathon.assignment.account.dto.request.TransferToSavingAccountRequestDto;
+import org.c4marathon.assignment.account.dto.request.TransferToOtherAccountRequestDto;
 import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
 import org.c4marathon.assignment.account.entity.Account;
 import org.c4marathon.assignment.account.entity.SavingAccount;
@@ -34,6 +34,7 @@ public class AccountService {
     private final SecurityService securityService;
 
     public static final int DAILY_LIMIT = 3_000_000;
+    public static final long CHARGING_UNIT = 10_000;
 
     // 회원 가입 시 메인 계좌 생성
     @Transactional(isolation = Isolation.READ_COMMITTED)
@@ -78,7 +79,7 @@ public class AccountService {
         Long memberId = securityService.findMember();
 
         // 계좌 정보 조회
-        Account account = accountRepository.findByRegularAccount(memberId)
+        Account account = accountRepository.findByAccount(memberId)
             .orElseThrow(() -> new BaseException(ErrorCode.REGULAR_ACCOUNT_DOES_NOT_EXIST.toString(),
                 FORBIDDEN.toString()));
 
@@ -99,30 +100,64 @@ public class AccountService {
 
     // 메인 계좌에서 적금 계좌로 이체
     @Transactional(isolation = Isolation.READ_COMMITTED)
-    public void transferFromRegularAccount(TransferToSavingAccountRequestDto transferToSavingAccountRequestDto) {
+    public void transferFromRegularAccount(TransferToOtherAccountRequestDto transferToOtherAccountRequestDto) {
 
         // 회원 정보 조회
         Long memberId = securityService.findMember();
 
         // 메인 계좌 및 적금 계좌 조회
-        Account regularAccount = accountRepository.findByRegularAccount(memberId)
+        Account regularAccount = accountRepository.findByAccount(memberId)
             .orElseThrow(
                 () -> new BaseException(ErrorCode.REGULAR_ACCOUNT_DOES_NOT_EXIST.toString(), FORBIDDEN.toString()));
 
         // 잔액이 부족하다면 예외 처리
-        if (regularAccount.getBalance() < transferToSavingAccountRequestDto.balance()) {
-            throw new BaseException(ErrorCode.INSUFFICIENT_BALANCE.toString(), HttpStatus.FORBIDDEN.toString());
+        if (regularAccount.getBalance() < transferToOtherAccountRequestDto.balance()) {
+            throw new BaseException(ErrorCode.INSUFFICIENT_BALANCE.toString(), FORBIDDEN.toString());
         }
 
-        regularAccount.transferBalance(regularAccount.getBalance() - transferToSavingAccountRequestDto.balance());
+        regularAccount.transferBalance(regularAccount.getBalance() - transferToOtherAccountRequestDto.balance());
 
         SavingAccount savingAccount = savingAccountRepository.findBySavingAccount(memberId,
-                transferToSavingAccountRequestDto.receiverAccountId())
+                transferToOtherAccountRequestDto.receiverAccountId())
             .orElseThrow(() -> new BaseException(ErrorCode.ACCOUNT_DOES_NOT_EXIST.toString(), FORBIDDEN.toString()));
 
-        savingAccount.transferBalance(savingAccount.getBalance() + transferToSavingAccountRequestDto.balance());
+        savingAccount.transferBalance(savingAccount.getBalance() + transferToOtherAccountRequestDto.balance());
 
         accountRepository.save(regularAccount);
         savingAccountRepository.save(savingAccount);
+    }
+
+    @Transactional(isolation = Isolation.READ_COMMITTED)
+    public void transferToOtherAccount(TransferToOtherAccountRequestDto transferToOtherAccountRequestDto) {
+        // 회원 정보 조회
+        Long memberId = securityService.findMember();
+
+        Account account = accountRepository.findByAccount(memberId).orElseThrow(
+            () -> new BaseException(ErrorCode.REGULAR_ACCOUNT_DOES_NOT_EXIST.toString(), FORBIDDEN.toString()));
+
+        // 계좌 잔액이 부족할 때 충전 메서드 호출
+        // 부족한 금액을 만원 단위로 충전
+        long money = account.getBalance() - transferToOtherAccountRequestDto.balance();
+        if (money < 0) {
+            // (부족한 금액을 10,000원으로 나눈 몫의 + 1) * 10000 만큼 충전
+            long balance = ((Math.abs(money) / CHARGING_UNIT) + 1) * 10000;
+            rechargeAccount(new RechargeAccountRequestDto(account.getId(), balance));
+            // 새롭게 충전한 금액 - 부족한 금액
+            account.transferBalance(balance + money);
+        } else {
+            // 계좌 잔액이 부족하지 않다면, 잔액 - 요청 금액
+            account.transferBalance(money);
+        }
+
+        accountRepository.save(account);
+
+        Account otherAccount = accountRepository.findByOtherAccount(
+                transferToOtherAccountRequestDto.receiverAccountId())
+            .orElseThrow(
+                () -> new BaseException(ErrorCode.REGULAR_ACCOUNT_DOES_NOT_EXIST.toString(), FORBIDDEN.toString()));
+
+        otherAccount.transferBalance(otherAccount.getBalance() + transferToOtherAccountRequestDto.balance());
+
+        accountRepository.save(otherAccount);
     }
 }

--- a/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
@@ -2,23 +2,20 @@ package org.c4marathon.assignment.account.service;
 
 import static org.springframework.http.HttpStatus.*;
 
-import java.util.List;
-
-import org.c4marathon.assignment.account.dto.request.AccountRequestDto;
 import org.c4marathon.assignment.account.dto.request.RechargeAccountRequestDto;
-import org.c4marathon.assignment.account.dto.request.SavingAccountRequestDto;
+import org.c4marathon.assignment.account.dto.request.TransferToSavingAccountRequestDto;
 import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
 import org.c4marathon.assignment.account.entity.Account;
+import org.c4marathon.assignment.account.entity.SavingAccount;
 import org.c4marathon.assignment.account.entity.Type;
 import org.c4marathon.assignment.account.repository.AccountRepository;
+import org.c4marathon.assignment.account.repository.SavingAccountRepository;
 import org.c4marathon.assignment.auth.service.SecurityService;
 import org.c4marathon.assignment.member.entity.Member;
 import org.c4marathon.assignment.member.service.MemberService;
 import org.c4marathon.assignment.util.exceptions.BaseException;
 import org.c4marathon.assignment.util.exceptions.ErrorCode;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +26,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AccountService {
     private final AccountRepository accountRepository;
+
+    private final SavingAccountRepository savingAccountRepository;
 
     private final MemberService memberService;
 
@@ -46,22 +45,6 @@ public class AccountService {
         accountRepository.save(account);
     }
 
-    // 계좌 생성
-    @Transactional(isolation = Isolation.READ_COMMITTED)
-    public void saveAccount(AccountRequestDto accountRequestDto) {
-
-        Long memberId = securityService.findMember();
-        Member member = memberService.getMemberById(memberId);
-        Account account = createAccount(accountRequestDto.type(), member);
-
-        accountRepository.save(account);
-
-        // 메인 계좌가 존재하지 않을 시 확인 후 생성
-        if (!isMainAccount(memberId)) {
-            accountRepository.save(createAccount(Type.REGULAR_ACCOUNT, member));
-        }
-    }
-
     // 메인 계좌가 존재하는지 확인
     public boolean isMainAccount(Long memberId) {
         return accountRepository.existsAccountByMemberIdAndType(memberId, Type.REGULAR_ACCOUNT);
@@ -76,17 +59,15 @@ public class AccountService {
             .build();
     }
 
-    // 계좌 전체 조회
-    public List<AccountResponseDto> findAccount() {
+    // 메인 계좌 조회
+    public AccountResponseDto findAccount() {
 
         // 회원 정보 조회
         Long memberId = securityService.findMember();
-        List<Account> accountList = accountRepository.findByMemberId(memberId);
+        Account account = accountRepository.findByMemberId(memberId);
 
         // 계좌 조회 후 Entity를 Dto로 변환 후 리턴
-        return accountList.stream()
-            .map(AccountResponseDto::entityToDto)
-            .toList();
+        return AccountResponseDto.entityToDto(account);
     }
 
     // 메인 계좌 잔액 충전
@@ -118,7 +99,7 @@ public class AccountService {
 
     // 메인 계좌에서 적금 계좌로 이체
     @Transactional(isolation = Isolation.READ_COMMITTED)
-    public void transferFromRegularAccount(SavingAccountRequestDto savingAccountRequestDto) {
+    public void transferFromRegularAccount(TransferToSavingAccountRequestDto transferToSavingAccountRequestDto) {
 
         // 회원 정보 조회
         Long memberId = securityService.findMember();
@@ -129,18 +110,19 @@ public class AccountService {
                 () -> new BaseException(ErrorCode.REGULAR_ACCOUNT_DOES_NOT_EXIST.toString(), FORBIDDEN.toString()));
 
         // 잔액이 부족하다면 예외 처리
-        if (regularAccount.getBalance() < savingAccountRequestDto.balance()) {
+        if (regularAccount.getBalance() < transferToSavingAccountRequestDto.balance()) {
             throw new BaseException(ErrorCode.INSUFFICIENT_BALANCE.toString(), HttpStatus.FORBIDDEN.toString());
         }
 
-        regularAccount.transferBalance(regularAccount.getBalance() - savingAccountRequestDto.balance());
+        regularAccount.transferBalance(regularAccount.getBalance() - transferToSavingAccountRequestDto.balance());
 
-        Account savingAccount = accountRepository.findByAccount(memberId,
-                savingAccountRequestDto.receiverAccountId())
+        SavingAccount savingAccount = savingAccountRepository.findBySavingAccount(memberId,
+                transferToSavingAccountRequestDto.receiverAccountId())
             .orElseThrow(() -> new BaseException(ErrorCode.ACCOUNT_DOES_NOT_EXIST.toString(), FORBIDDEN.toString()));
 
-        savingAccount.transferBalance(savingAccount.getBalance() + savingAccountRequestDto.balance());
+        savingAccount.transferBalance(savingAccount.getBalance() + transferToSavingAccountRequestDto.balance());
 
-        accountRepository.saveAll(List.of(regularAccount, savingAccount));
+        accountRepository.save(regularAccount);
+        savingAccountRepository.save(savingAccount);
     }
 }

--- a/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
@@ -2,6 +2,10 @@ package org.c4marathon.assignment.account.service;
 
 import static org.springframework.http.HttpStatus.*;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Objects;
+
 import org.c4marathon.assignment.account.dto.request.RechargeAccountRequestDto;
 import org.c4marathon.assignment.account.dto.request.TransferToOtherAccountRequestDto;
 import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
@@ -84,6 +88,10 @@ public class AccountService {
                 FORBIDDEN.toString()));
 
         int dailyLimit = account.getDailyLimit() + rechargeAccountRequestDto.balance().intValue();
+        // 날짜가 다를 땐 일일한도를 초기화 한 뒤 계산
+        if (!Objects.equals(account.getDailyLimitUpdateAt(), LocalDate.now(ZoneId.of("Asia/Seoul")))) {
+            dailyLimit = rechargeAccountRequestDto.balance().intValue();
+        }
         Long balance = account.getBalance() + rechargeAccountRequestDto.balance();
 
         // 충전 한도 확인

--- a/src/main/java/org/c4marathon/assignment/account/service/SavingAccountService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/SavingAccountService.java
@@ -1,0 +1,63 @@
+package org.c4marathon.assignment.account.service;
+
+import java.util.List;
+
+import org.c4marathon.assignment.account.dto.request.AccountRequestDto;
+import org.c4marathon.assignment.account.dto.response.SavingAccountResponseDto;
+import org.c4marathon.assignment.account.entity.Account;
+import org.c4marathon.assignment.account.entity.SavingAccount;
+import org.c4marathon.assignment.account.entity.Type;
+import org.c4marathon.assignment.account.repository.SavingAccountRepository;
+import org.c4marathon.assignment.auth.service.SecurityService;
+import org.c4marathon.assignment.member.entity.Member;
+import org.c4marathon.assignment.member.service.MemberService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SavingAccountService {
+
+    private final SecurityService securityService;
+
+    private final MemberService memberService;
+
+    private final AccountService accountService;
+
+    private final SavingAccountRepository savingAccountRepository;
+
+    public SavingAccount createSavingAccount(Type type, Member member) {
+        return SavingAccount.builder()
+            .type(type)
+            .member(member)
+            .build();
+    }
+
+    // 적금 계좌 생성
+    @Transactional(isolation = Isolation.READ_COMMITTED)
+    public void saveSavingAccount(AccountRequestDto accountRequestDto) {
+
+        Long memberId = securityService.findMember();
+        Member member = memberService.getMemberById(memberId);
+        SavingAccount savingAccount = createSavingAccount(accountRequestDto.type(), member);
+        savingAccountRepository.save(savingAccount);
+
+        // 메인 계좌가 존재하지 않을 시 확인 후 생성
+        if (!accountService.isMainAccount(memberId)) {
+            accountService.saveMainAccount(memberId);
+        }
+    }
+
+    // 사용자의 전체 적금 계좌 조회
+    public List<SavingAccountResponseDto> findSavingAccount() {
+
+        Long memberId = securityService.findMember();
+        List<SavingAccount> savingAccounts = savingAccountRepository.findByMemberId(memberId);
+        return savingAccounts.stream()
+            .map(SavingAccountResponseDto::entityToDto)
+            .toList();
+    }
+}

--- a/src/main/java/org/c4marathon/assignment/account/service/SavingAccountService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/SavingAccountService.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.c4marathon.assignment.account.dto.request.AccountRequestDto;
 import org.c4marathon.assignment.account.dto.response.SavingAccountResponseDto;
-import org.c4marathon.assignment.account.entity.Account;
 import org.c4marathon.assignment.account.entity.SavingAccount;
 import org.c4marathon.assignment.account.entity.Type;
 import org.c4marathon.assignment.account.repository.SavingAccountRepository;

--- a/src/main/java/org/c4marathon/assignment/account/validation/TypeValidator.java
+++ b/src/main/java/org/c4marathon/assignment/account/validation/TypeValidator.java
@@ -1,0 +1,19 @@
+package org.c4marathon.assignment.account.validation;
+
+import java.util.EnumSet;
+
+import org.c4marathon.assignment.account.entity.Type;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class TypeValidator implements ConstraintValidator<ValidType, Type> {
+    @Override
+    public boolean isValid(Type value, ConstraintValidatorContext context) {
+        return value == null || EnumSet.of(
+            Type.REGULAR_ACCOUNT,
+            Type.INSTALLMENT_SAVINGS_ACCOUNT,
+            Type.FREEDOM_INSTALLMENT_SAVINGS_ACCOUNT
+        ).contains(value);
+    }
+}

--- a/src/main/java/org/c4marathon/assignment/account/validation/TypeValidator.java
+++ b/src/main/java/org/c4marathon/assignment/account/validation/TypeValidator.java
@@ -10,7 +10,7 @@ import jakarta.validation.ConstraintValidatorContext;
 public class TypeValidator implements ConstraintValidator<ValidType, Type> {
     @Override
     public boolean isValid(Type value, ConstraintValidatorContext context) {
-        return value == null || EnumSet.of(
+        return EnumSet.of(
             Type.REGULAR_ACCOUNT,
             Type.INSTALLMENT_SAVINGS_ACCOUNT,
             Type.FREEDOM_INSTALLMENT_SAVINGS_ACCOUNT

--- a/src/main/java/org/c4marathon/assignment/account/validation/ValidType.java
+++ b/src/main/java/org/c4marathon/assignment/account/validation/ValidType.java
@@ -1,0 +1,18 @@
+package org.c4marathon.assignment.account.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = TypeValidator.class)
+public @interface ValidType {
+    String message() default "올바르지 못한 입력입니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/c4marathon/assignment/auth/jwt/JwtTokenFilter.java
+++ b/src/main/java/org/c4marathon/assignment/auth/jwt/JwtTokenFilter.java
@@ -42,7 +42,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
         }
 
         // Jwt Token에서 memberId 추출
-        Long memberId = JwtTokenUtil.getMemberEmail(authorizationHeader, secretKey);
+        Long memberId = JwtTokenUtil.getMemberId(authorizationHeader, secretKey);
 
         // loginUser 정보로 UsernamePasswordAuthenticationToken 발급
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(

--- a/src/main/java/org/c4marathon/assignment/auth/jwt/JwtTokenUtil.java
+++ b/src/main/java/org/c4marathon/assignment/auth/jwt/JwtTokenUtil.java
@@ -24,9 +24,9 @@ public class JwtTokenUtil {
             .compact();
     }
 
-    // Claims에서 memberEmail 꺼내기
-    public static Long getMemberEmail(String token, String secretKey) {
-        return (Long)extractClaims(token, secretKey).get(CLAIM_KEY_MEMBER_ID);
+    // Claims에서 memberId 꺼내기
+    public static Long getMemberId(String token, String secretKey) {
+        return ((Number) extractClaims(token, secretKey).get(CLAIM_KEY_MEMBER_ID)).longValue();
     }
 
     // 발급된 Token이 만료 시간이 지났는지 체크

--- a/src/main/java/org/c4marathon/assignment/auth/service/SecurityService.java
+++ b/src/main/java/org/c4marathon/assignment/auth/service/SecurityService.java
@@ -1,0 +1,13 @@
+package org.c4marathon.assignment.auth.service;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SecurityService {
+    public Long findMember() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return (Long)authentication.getPrincipal();
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -7,4 +7,4 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -7,4 +7,4 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -7,4 +7,4 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate

--- a/src/test/java/org/c4marathon/assignment/account/concurrency/ConcurrencyTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/concurrency/ConcurrencyTest.java
@@ -180,9 +180,6 @@ public class ConcurrencyTest {
             Account resultMainAccount = accountRepository.findById(mainAccount.getId()).orElseThrow();
             Account resultOtherAccount = accountRepository.findById(otherAccount.getId()).orElseThrow();
 
-            System.out.println(resultMainAccount.getBalance());
-            System.out.println(resultOtherAccount.getBalance());
-
             // then
             assertEquals(threadCount, successCount.get());
             assertEquals(0, failCount.get());

--- a/src/test/java/org/c4marathon/assignment/account/concurrency/ConcurrencyTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/concurrency/ConcurrencyTest.java
@@ -10,7 +10,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.c4marathon.assignment.account.dto.request.RechargeAccountRequestDto;
-import org.c4marathon.assignment.account.dto.request.SavingAccountRequestDto;
+import org.c4marathon.assignment.account.dto.request.TransferToSavingAccountRequestDto;
 import org.c4marathon.assignment.account.entity.Account;
 import org.c4marathon.assignment.account.entity.Type;
 import org.c4marathon.assignment.account.repository.AccountRepository;
@@ -105,7 +105,7 @@ public class ConcurrencyTest {
                         accountService.rechargeAccount(new RechargeAccountRequestDto(mainAccount.getId(), 10000L));
                         // 적금 계좌로 출금
                         accountService.transferFromRegularAccount(
-                            new SavingAccountRequestDto(10000L, savingAccount.getId()));
+                            new TransferToSavingAccountRequestDto(10000L, savingAccount.getId()));
                         successCount.getAndIncrement();
                     } catch (Exception e) {
                         failCount.getAndIncrement();

--- a/src/test/java/org/c4marathon/assignment/account/concurrency/ConcurrencyTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/concurrency/ConcurrencyTest.java
@@ -9,7 +9,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.c4marathon.assignment.account.dto.request.RechargeAccountRequestDto;
-import org.c4marathon.assignment.account.dto.request.TransferToSavingAccountRequestDto;
+import org.c4marathon.assignment.account.dto.request.TransferToOtherAccountRequestDto;
 import org.c4marathon.assignment.account.entity.Account;
 import org.c4marathon.assignment.account.entity.SavingAccount;
 import org.c4marathon.assignment.account.entity.Type;
@@ -117,7 +117,7 @@ public class ConcurrencyTest {
                         accountService.rechargeAccount(new RechargeAccountRequestDto(mainAccount.getId(), 10000L));
                         // 적금 계좌로 출금
                         accountService.transferFromRegularAccount(
-                            new TransferToSavingAccountRequestDto(10000L, savingAccount.getId()));
+                            new TransferToOtherAccountRequestDto(10000L, savingAccount.getId()));
                         successCount.getAndIncrement();
                     } catch (Exception e) {
                         failCount.getAndIncrement();

--- a/src/test/java/org/c4marathon/assignment/account/controller/AccountControllerTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/controller/AccountControllerTest.java
@@ -10,7 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.Objects;
 
 import org.c4marathon.assignment.account.dto.request.RechargeAccountRequestDto;
-import org.c4marathon.assignment.account.dto.request.TransferToSavingAccountRequestDto;
+import org.c4marathon.assignment.account.dto.request.TransferToOtherAccountRequestDto;
 import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
 import org.c4marathon.assignment.account.entity.Account;
 import org.c4marathon.assignment.account.service.AccountService;
@@ -149,14 +149,14 @@ public class AccountControllerTest {
         void transferFromRegularAccountTest() throws Exception {
 
             // given
-            TransferToSavingAccountRequestDto transferToSavingAccountRequestDto = new TransferToSavingAccountRequestDto(
+            TransferToOtherAccountRequestDto transferToOtherAccountRequestDto = new TransferToOtherAccountRequestDto(
                 10000L, 2L);
-            willDoNothing().given(accountService).transferFromRegularAccount(transferToSavingAccountRequestDto);
+            willDoNothing().given(accountService).transferFromRegularAccount(transferToOtherAccountRequestDto);
 
             // when then
             mockMvc.perform(post(REQUEST_URL + "/saving").header("Authorization", token)
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(transferToSavingAccountRequestDto)))
+                    .content(objectMapper.writeValueAsString(transferToOtherAccountRequestDto)))
                 .andExpect(status().isNoContent());
         }
 
@@ -165,16 +165,16 @@ public class AccountControllerTest {
         void transferFromRegularAccountErrorTest() throws Exception {
 
             // given
-            TransferToSavingAccountRequestDto transferToSavingAccountRequestDto = new TransferToSavingAccountRequestDto(
+            TransferToOtherAccountRequestDto transferToOtherAccountRequestDto = new TransferToOtherAccountRequestDto(
                 50000L, 2L);
             BaseException baseException = ErrorCode.INSUFFICIENT_BALANCE.baseException("잔액이 부족합니다.");
             willThrow(baseException).given(accountService)
-                .transferFromRegularAccount(transferToSavingAccountRequestDto);
+                .transferFromRegularAccount(transferToOtherAccountRequestDto);
 
             // when
             MvcResult mvcResult = mockMvc.perform(post(REQUEST_URL + "/saving").header("Authorization", token)
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(transferToSavingAccountRequestDto)))
+                    .content(objectMapper.writeValueAsString(transferToOtherAccountRequestDto)))
                 .andExpect(status().isForbidden())
                 .andReturn();
 

--- a/src/test/java/org/c4marathon/assignment/account/controller/AccountControllerTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/controller/AccountControllerTest.java
@@ -182,5 +182,42 @@ public class AccountControllerTest {
             String message = Objects.requireNonNull(mvcResult.getResolvedException()).getMessage();
             assertThat(message).contains("잔액이 부족합니다.");
         }
+
+        @DisplayName("사용자의 메인 계좌에서 친구의 메인 계좌로 송금 시 올바르게 송금이 이루어진다.")
+        @Test
+        void transferToOtherAccountSuccessTest() throws Exception {
+            // given
+            TransferToOtherAccountRequestDto transferToOtherAccountRequestDto = new TransferToOtherAccountRequestDto(
+                50000L, 2L);
+            willDoNothing().given(accountService).transferToOtherAccount(transferToOtherAccountRequestDto);
+
+            // when then
+            mockMvc.perform(post(REQUEST_URL + "/transfer").header("Authorization", token)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(transferToOtherAccountRequestDto)))
+                .andExpect(status().isNoContent());
+        }
+
+        @DisplayName("사용자의 메인 계좌에서 친구의 메인 계좌로 송금 시 없는 계좌를 입력해 실패한다.")
+        @Test
+        void transferToOtherAccountFailedTest() throws Exception {
+            // given
+            TransferToOtherAccountRequestDto transferToOtherAccountRequestDto = new TransferToOtherAccountRequestDto(
+                50000L, 2L);
+            BaseException baseException = ErrorCode.ACCOUNT_DOES_NOT_EXIST.baseException("계좌가 존재하지 않습니다.");
+            willThrow(baseException).given(accountService)
+                .transferToOtherAccount(transferToOtherAccountRequestDto);
+
+            // when
+            MvcResult mvcResult = mockMvc.perform(post(REQUEST_URL + "/transfer").header("Authorization", token)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(transferToOtherAccountRequestDto)))
+                .andExpect(status().isForbidden())
+                .andReturn();
+
+            // then
+            String message = Objects.requireNonNull(mvcResult.getResolvedException()).getMessage();
+            assertThat(message).contains("계좌가 존재하지 않습니다.");
+        }
     }
 }

--- a/src/test/java/org/c4marathon/assignment/account/controller/AccountControllerTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/controller/AccountControllerTest.java
@@ -154,7 +154,7 @@ public class AccountControllerTest {
             willDoNothing().given(accountService).transferFromRegularAccount(transferToOtherAccountRequestDto);
 
             // when then
-            mockMvc.perform(post(REQUEST_URL + "/saving").header("Authorization", token)
+            mockMvc.perform(post(REQUEST_URL + "/transfer/saving").header("Authorization", token)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(transferToOtherAccountRequestDto)))
                 .andExpect(status().isNoContent());
@@ -172,7 +172,7 @@ public class AccountControllerTest {
                 .transferFromRegularAccount(transferToOtherAccountRequestDto);
 
             // when
-            MvcResult mvcResult = mockMvc.perform(post(REQUEST_URL + "/saving").header("Authorization", token)
+            MvcResult mvcResult = mockMvc.perform(post(REQUEST_URL + "/transfer/saving").header("Authorization", token)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(transferToOtherAccountRequestDto)))
                 .andExpect(status().isForbidden())
@@ -192,7 +192,7 @@ public class AccountControllerTest {
             willDoNothing().given(accountService).transferToOtherAccount(transferToOtherAccountRequestDto);
 
             // when then
-            mockMvc.perform(post(REQUEST_URL + "/transfer").header("Authorization", token)
+            mockMvc.perform(post(REQUEST_URL + "/transfer/regular").header("Authorization", token)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(transferToOtherAccountRequestDto)))
                 .andExpect(status().isNoContent());
@@ -209,7 +209,7 @@ public class AccountControllerTest {
                 .transferToOtherAccount(transferToOtherAccountRequestDto);
 
             // when
-            MvcResult mvcResult = mockMvc.perform(post(REQUEST_URL + "/transfer").header("Authorization", token)
+            MvcResult mvcResult = mockMvc.perform(post(REQUEST_URL + "/transfer/regular").header("Authorization", token)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(transferToOtherAccountRequestDto)))
                 .andExpect(status().isForbidden())

--- a/src/test/java/org/c4marathon/assignment/account/controller/AccountControllerTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/controller/AccountControllerTest.java
@@ -3,7 +3,6 @@ package org.c4marathon.assignment.account.controller;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.*;
 import static org.mockito.BDDMockito.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -11,7 +10,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.List;
 import java.util.Objects;
 
-import org.c4marathon.assignment.account.dto.request.AccountRequestDto;
 import org.c4marathon.assignment.account.dto.request.RechargeAccountRequestDto;
 import org.c4marathon.assignment.account.dto.request.TransferToSavingAccountRequestDto;
 import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
@@ -42,7 +40,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -52,7 +49,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @Import(SecurityConfig.class)
 @TestInstance(value = PER_CLASS)
 @ActiveProfiles("test")
-public class AccoutControllerTest {
+public class AccountControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -104,41 +101,6 @@ public class AccoutControllerTest {
     @AfterAll
     void afterAll() {
         mockedStatic.close();
-    }
-
-    @Nested
-    @DisplayName("계좌 생성 테스트")
-    class Create {
-
-        @DisplayName("계좌 생성 요청이 들어오면 요청에 따른 타입의 계좌를 생성한다.")
-        @Test
-        void createAccountTest() throws Exception {
-
-            // given
-            Member member = Member.builder()
-                .email("test@naver.com")
-                .password("test")
-                .name("test")
-                .build();
-            Account account = Account.builder()
-                .type(Type.ADDITIONAL_ACCOUNT)
-                .member(member)
-                .build();
-            AccountRequestDto accountRequestDto = new AccountRequestDto(Type.ADDITIONAL_ACCOUNT);
-            willDoNothing().given(accountService).saveAccount(accountRequestDto);
-            willReturn(member).given(memberService).getMemberById(member.getId());
-            willReturn(account).given(accountService).createAccount(Type.ADDITIONAL_ACCOUNT, member);
-            willReturn(true).given(accountService).isMainAccount(0L);
-
-            // when
-            ResultActions resultActions = mockMvc.perform(post(REQUEST_URL).header("Authorization", token)
-                .contentType(MediaType.APPLICATION_JSON)
-                .with(csrf())
-                .content(objectMapper.writeValueAsString(accountRequestDto)));
-
-            // then
-            resultActions.andExpect(status().isNoContent());
-        }
     }
 
     @Nested

--- a/src/test/java/org/c4marathon/assignment/account/controller/AccoutControllerTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/controller/AccoutControllerTest.java
@@ -21,6 +21,7 @@ import org.c4marathon.assignment.account.repository.AccountRepository;
 import org.c4marathon.assignment.account.service.AccountService;
 import org.c4marathon.assignment.auth.config.SecurityConfig;
 import org.c4marathon.assignment.auth.jwt.JwtTokenUtil;
+import org.c4marathon.assignment.auth.service.SecurityService;
 import org.c4marathon.assignment.member.entity.Member;
 import org.c4marathon.assignment.member.service.MemberService;
 import org.c4marathon.assignment.util.exceptions.BaseException;
@@ -64,6 +65,9 @@ public class AccoutControllerTest {
 
     @MockBean
     private MemberService memberService;
+
+    @MockBean
+    private SecurityService securityService;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -158,7 +162,7 @@ public class AccoutControllerTest {
             List<AccountResponseDto> accountResponseDtoList = accountList.stream()
                 .map(AccountResponseDto::entityToDto)
                 .toList();
-            willReturn(0L).given(accountService).findMember();
+            willReturn(0L).given(securityService).findMember();
             willReturn(accountResponseDtoList).given(accountService).findAccount();
             willReturn(accountList).given(accountRepository).findByMemberId(0L);
 

--- a/src/test/java/org/c4marathon/assignment/account/controller/AccoutControllerTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/controller/AccoutControllerTest.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 
 import org.c4marathon.assignment.account.dto.request.AccountRequestDto;
 import org.c4marathon.assignment.account.dto.request.RechargeAccountRequestDto;
-import org.c4marathon.assignment.account.dto.request.SavingAccountRequestDto;
+import org.c4marathon.assignment.account.dto.request.TransferToSavingAccountRequestDto;
 import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
 import org.c4marathon.assignment.account.entity.Account;
 import org.c4marathon.assignment.account.entity.Type;
@@ -215,13 +215,13 @@ public class AccoutControllerTest {
         void transferFromRegularAccountTest() throws Exception {
 
             // given
-            SavingAccountRequestDto savingAccountRequestDto = new SavingAccountRequestDto(10000L, 2L);
-            willDoNothing().given(accountService).transferFromRegularAccount(savingAccountRequestDto);
+            TransferToSavingAccountRequestDto transferToSavingAccountRequestDto = new TransferToSavingAccountRequestDto(10000L, 2L);
+            willDoNothing().given(accountService).transferFromRegularAccount(transferToSavingAccountRequestDto);
 
             // when then
             mockMvc.perform(post(REQUEST_URL + "/saving").header("Authorization", token)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(savingAccountRequestDto))).andExpect(status().isNoContent());
+                .content(objectMapper.writeValueAsString(transferToSavingAccountRequestDto))).andExpect(status().isNoContent());
         }
 
         @DisplayName("메인 계좌에서 적금 계좌로 입금 시 잔액 부족하다면 오류가 발생한다.")
@@ -229,14 +229,14 @@ public class AccoutControllerTest {
         void transferFromRegularAccountErrorTest() throws Exception {
 
             // given
-            SavingAccountRequestDto savingAccountRequestDto = new SavingAccountRequestDto(50000L, 2L);
+            TransferToSavingAccountRequestDto transferToSavingAccountRequestDto = new TransferToSavingAccountRequestDto(50000L, 2L);
             BaseException baseException = ErrorCode.INSUFFICIENT_BALANCE.baseException("잔액이 부족합니다.");
-            willThrow(baseException).given(accountService).transferFromRegularAccount(savingAccountRequestDto);
+            willThrow(baseException).given(accountService).transferFromRegularAccount(transferToSavingAccountRequestDto);
 
             // when
             MvcResult mvcResult = mockMvc.perform(post(REQUEST_URL + "/saving").header("Authorization", token)
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(savingAccountRequestDto)))
+                    .content(objectMapper.writeValueAsString(transferToSavingAccountRequestDto)))
                 .andExpect(status().isForbidden())
                 .andReturn();
 

--- a/src/test/java/org/c4marathon/assignment/account/controller/SavingAccountControllerTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/controller/SavingAccountControllerTest.java
@@ -1,0 +1,122 @@
+package org.c4marathon.assignment.account.controller;
+
+import static org.junit.jupiter.api.TestInstance.Lifecycle.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.c4marathon.assignment.account.dto.request.AccountRequestDto;
+import org.c4marathon.assignment.account.dto.response.SavingAccountResponseDto;
+import org.c4marathon.assignment.account.service.SavingAccountService;
+import org.c4marathon.assignment.auth.config.SecurityConfig;
+import org.c4marathon.assignment.auth.jwt.JwtTokenUtil;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.MockedStatic;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(SavingAccountController.class)
+@Import(SecurityConfig.class)
+@TestInstance(value = PER_CLASS)
+@ActiveProfiles("test")
+public class SavingAccountControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SavingAccountService savingAccountService;
+
+    private final String REQUEST_URL = "/accounts/savings";
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private String token;
+
+    @Value("${jwt.key}")
+    private String secretKey;
+
+    @Value("${jwt.max-age}")
+    private Long expireTimeMs;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    // static 메서드 테스트
+    private static MockedStatic<JwtTokenUtil> mockedStatic;
+
+    // 토큰 생성
+    private String createToken() {
+        return JwtTokenUtil.createToken(0L, secretKey, expireTimeMs);
+    }
+
+    @BeforeAll
+    void setUp() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).apply(springSecurity()).build();
+        token = createToken();
+        mockedStatic = mockStatic(JwtTokenUtil.class);
+    }
+
+    @AfterAll
+    void afterAll() {
+        mockedStatic.close();
+    }
+
+    @Nested
+    @DisplayName("계좌 생성 테스트")
+    class Create {
+
+        @DisplayName("적금 계좌 생성 요청에 따라 적금 계좌를 생성한다.")
+        @Test
+        void createSavingAccountTest() throws Exception {
+            // given
+            AccountRequestDto accountRequestDto = mock(AccountRequestDto.class);
+            willDoNothing().given(savingAccountService).saveSavingAccount(accountRequestDto);
+
+            // when
+            savingAccountService.saveSavingAccount(accountRequestDto);
+
+            // then
+            mockMvc.perform(post(REQUEST_URL).header("Authorization", token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(accountRequestDto))).andExpect(status().isNoContent());
+        }
+    }
+
+    @Nested
+    @DisplayName("적금 계좌 조회 테스트")
+    class Read {
+
+        @DisplayName("Authorization 헤더로 전달 받은 토큰을 통해 회원의 계좌를 조회한다.")
+        @Test
+        void findAccountTest() throws Exception {
+            // given
+            SavingAccountResponseDto savingAccountResponseDto = mock(SavingAccountResponseDto.class);
+            List<SavingAccountResponseDto> savingAccountResponseDtoList = List.of(savingAccountResponseDto);
+
+            willReturn(savingAccountResponseDtoList).given(savingAccountService).findSavingAccount();
+
+            // when then
+            mockMvc.perform(get(REQUEST_URL).header("Authorization", token)).andExpect(status().isOk()).andReturn();
+        }
+    }
+}

--- a/src/test/java/org/c4marathon/assignment/account/controller/SavingAccountControllerTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/controller/SavingAccountControllerTest.java
@@ -45,7 +45,7 @@ public class SavingAccountControllerTest {
     @MockBean
     private SavingAccountService savingAccountService;
 
-    private final String REQUEST_URL = "/accounts/savings";
+    private final String REQUEST_URL = "/accounts/saving";
 
     @Autowired
     private ObjectMapper objectMapper;

--- a/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
@@ -133,7 +133,7 @@ public class AccountServiceTest {
             Account account = mock(Account.class);
             RechargeAccountRequestDto requestDto = new RechargeAccountRequestDto(accountId, balance);
 
-            given(accountRepository.findByAccount(memberId)).willReturn(Optional.of(account));
+            given(accountRepository.findAccountByMemberId(memberId)).willReturn(Optional.of(account));
             given(account.getDailyLimit()).willReturn(0);
             given(account.getBalance()).willReturn(0L);
 
@@ -154,7 +154,7 @@ public class AccountServiceTest {
             Account account = mock(Account.class);
             RechargeAccountRequestDto requestDto = new RechargeAccountRequestDto(accountId, balance);
 
-            given(accountRepository.findByAccount(memberId)).willReturn(Optional.of(account));
+            given(accountRepository.findAccountByMemberId(memberId)).willReturn(Optional.of(account));
             given(account.getDailyLimit()).willReturn(3000000);
             given(account.getBalance()).willReturn(0L);
             given(account.getDailyLimitUpdateAt()).willReturn(LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1));
@@ -176,7 +176,7 @@ public class AccountServiceTest {
             Account account = mock(Account.class);
             RechargeAccountRequestDto requestDto = new RechargeAccountRequestDto(accountId, balance);
 
-            given(accountRepository.findByAccount(memberId)).willReturn(Optional.of(account));
+            given(accountRepository.findAccountByMemberId(memberId)).willReturn(Optional.of(account));
             given(account.getDailyLimit()).willReturn(DAILY_LIMIT);
             given(account.getBalance()).willReturn(0L);
             given(account.getDailyLimitUpdateAt()).willReturn(LocalDate.now(ZoneId.of("Asia/Seoul")));
@@ -200,7 +200,7 @@ public class AccountServiceTest {
                 receiverAccountd);
 
             given(regularAccount.getBalance()).willReturn(balance);
-            given(accountRepository.findByAccount(memberId)).willReturn(Optional.of(regularAccount));
+            given(accountRepository.findAccountByMemberId(memberId)).willReturn(Optional.of(regularAccount));
             given(savingAccountRepository.findBySavingAccount(memberId, requestDto.receiverAccountId())).willReturn(
                 Optional.of(savingAccount));
 
@@ -208,7 +208,7 @@ public class AccountServiceTest {
             accountService.transferFromRegularAccount(requestDto);
 
             // then
-            then(accountRepository).should(times(1)).findByAccount(memberId);
+            then(accountRepository).should(times(1)).findAccountByMemberId(memberId);
             then(savingAccountRepository).should(times(1))
                 .findBySavingAccount(memberId, requestDto.receiverAccountId());
         }
@@ -221,8 +221,7 @@ public class AccountServiceTest {
             Account regularAccount = mock(Account.class);
             TransferToOtherAccountRequestDto requestDto = new TransferToOtherAccountRequestDto(balance, accountId);
 
-            given(regularAccount.getBalance()).willReturn(0L);
-            given(accountRepository.findByAccount(memberId)).willReturn(Optional.of(regularAccount));
+            given(accountRepository.findAccountByMemberId(memberId)).willReturn(Optional.of(regularAccount));
 
             // when
             Exception exception = assertThrows(BaseException.class,
@@ -242,7 +241,7 @@ public class AccountServiceTest {
                 receiverAccountd);
 
             Account account = mock(Account.class);
-            given(accountRepository.findByAccount(memberId)).willReturn(Optional.of(account));
+            given(accountRepository.findAccountByMemberId(memberId)).willReturn(Optional.of(account));
 
             Account otherAccount = mock(Account.class);
             given(account.getBalance()).willReturn(balance);
@@ -253,7 +252,7 @@ public class AccountServiceTest {
             accountService.transferToOtherAccount(requestDto);
 
             // then
-            then(accountRepository).should(times(1)).findByAccount(memberId);
+            then(accountRepository).should(times(1)).findAccountByMemberId(memberId);
             then(accountRepository).should(times(1)).findByOtherAccount(requestDto.receiverAccountId());
         }
 
@@ -267,7 +266,7 @@ public class AccountServiceTest {
                 receiverAccountd);
 
             Account account = mock(Account.class);
-            given(accountRepository.findByAccount(memberId)).willReturn(Optional.of(account));
+            given(accountRepository.findAccountByMemberId(memberId)).willReturn(Optional.of(account));
 
             Account otherAccount = mock(Account.class);
             given(account.getBalance()).willReturn(balance);
@@ -278,7 +277,7 @@ public class AccountServiceTest {
             accountService.transferToOtherAccount(requestDto);
 
             // then
-            then(accountRepository).should(times(2)).findByAccount(memberId);
+            then(accountRepository).should(times(2)).findAccountByMemberId(memberId);
             then(accountRepository).should(times(1)).findByOtherAccount(requestDto.receiverAccountId());
         }
 
@@ -292,7 +291,7 @@ public class AccountServiceTest {
                 receiverAccountd);
 
             Account account = mock(Account.class);
-            given(accountRepository.findByAccount(memberId)).willReturn(Optional.of(account));
+            given(accountRepository.findAccountByMemberId(memberId)).willReturn(Optional.of(account));
             given(account.getBalance()).willReturn(balance);
 
             BaseException baseException = ErrorCode.ACCOUNT_DOES_NOT_EXIST.baseException("계좌가 존재하지 않습니다.");

--- a/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
@@ -15,6 +15,7 @@ import org.c4marathon.assignment.account.dto.request.TransferToOtherAccountReque
 import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
 import org.c4marathon.assignment.account.entity.Account;
 import org.c4marathon.assignment.account.entity.SavingAccount;
+import org.c4marathon.assignment.account.entity.Type;
 import org.c4marathon.assignment.account.repository.AccountRepository;
 import org.c4marathon.assignment.account.repository.SavingAccountRepository;
 import org.c4marathon.assignment.auth.service.SecurityService;
@@ -133,7 +134,7 @@ public class AccountServiceTest {
             Account account = mock(Account.class);
             RechargeAccountRequestDto requestDto = new RechargeAccountRequestDto(accountId, balance);
 
-            given(accountRepository.findAccountByMemberId(memberId)).willReturn(Optional.of(account));
+            given(accountRepository.findAccountByMemberId(memberId, Type.REGULAR_ACCOUNT)).willReturn(Optional.of(account));
             given(account.getDailyLimit()).willReturn(0);
             given(account.getBalance()).willReturn(0L);
 
@@ -154,7 +155,7 @@ public class AccountServiceTest {
             Account account = mock(Account.class);
             RechargeAccountRequestDto requestDto = new RechargeAccountRequestDto(accountId, balance);
 
-            given(accountRepository.findAccountByMemberId(memberId)).willReturn(Optional.of(account));
+            given(accountRepository.findAccountByMemberId(memberId, Type.REGULAR_ACCOUNT)).willReturn(Optional.of(account));
             given(account.getDailyLimit()).willReturn(3000000);
             given(account.getBalance()).willReturn(0L);
             given(account.getDailyLimitUpdateAt()).willReturn(LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1));
@@ -176,7 +177,7 @@ public class AccountServiceTest {
             Account account = mock(Account.class);
             RechargeAccountRequestDto requestDto = new RechargeAccountRequestDto(accountId, balance);
 
-            given(accountRepository.findAccountByMemberId(memberId)).willReturn(Optional.of(account));
+            given(accountRepository.findAccountByMemberId(memberId, Type.REGULAR_ACCOUNT)).willReturn(Optional.of(account));
             given(account.getDailyLimit()).willReturn(DAILY_LIMIT);
             given(account.getBalance()).willReturn(0L);
             given(account.getDailyLimitUpdateAt()).willReturn(LocalDate.now(ZoneId.of("Asia/Seoul")));
@@ -200,7 +201,7 @@ public class AccountServiceTest {
                 receiverAccountd);
 
             given(regularAccount.getBalance()).willReturn(balance);
-            given(accountRepository.findAccountByMemberId(memberId)).willReturn(Optional.of(regularAccount));
+            given(accountRepository.findAccountByMemberId(memberId, Type.REGULAR_ACCOUNT)).willReturn(Optional.of(regularAccount));
             given(savingAccountRepository.findBySavingAccount(memberId, requestDto.receiverAccountId())).willReturn(
                 Optional.of(savingAccount));
 
@@ -208,7 +209,7 @@ public class AccountServiceTest {
             accountService.transferFromRegularAccount(requestDto);
 
             // then
-            then(accountRepository).should(times(1)).findAccountByMemberId(memberId);
+            then(accountRepository).should(times(1)).findAccountByMemberId(memberId, Type.REGULAR_ACCOUNT);
             then(savingAccountRepository).should(times(1))
                 .findBySavingAccount(memberId, requestDto.receiverAccountId());
         }
@@ -221,7 +222,7 @@ public class AccountServiceTest {
             Account regularAccount = mock(Account.class);
             TransferToOtherAccountRequestDto requestDto = new TransferToOtherAccountRequestDto(balance, accountId);
 
-            given(accountRepository.findAccountByMemberId(memberId)).willReturn(Optional.of(regularAccount));
+            given(accountRepository.findAccountByMemberId(memberId, Type.REGULAR_ACCOUNT)).willReturn(Optional.of(regularAccount));
 
             // when
             Exception exception = assertThrows(BaseException.class,
@@ -241,19 +242,19 @@ public class AccountServiceTest {
                 receiverAccountd);
 
             Account account = mock(Account.class);
-            given(accountRepository.findAccountByMemberId(memberId)).willReturn(Optional.of(account));
+            given(accountRepository.findAccountByMemberId(memberId, Type.REGULAR_ACCOUNT)).willReturn(Optional.of(account));
 
             Account otherAccount = mock(Account.class);
             given(account.getBalance()).willReturn(balance);
-            given(accountRepository.findByOtherAccount(requestDto.receiverAccountId())).willReturn(
+            given(accountRepository.findAccountById(requestDto.receiverAccountId())).willReturn(
                 Optional.of(otherAccount));
 
             // when
             accountService.transferToOtherAccount(requestDto);
 
             // then
-            then(accountRepository).should(times(1)).findAccountByMemberId(memberId);
-            then(accountRepository).should(times(1)).findByOtherAccount(requestDto.receiverAccountId());
+            then(accountRepository).should(times(1)).findAccountByMemberId(memberId, Type.REGULAR_ACCOUNT);
+            then(accountRepository).should(times(1)).findAccountById(requestDto.receiverAccountId());
         }
 
         @DisplayName("메인 계좌에서 적금 계좌로 이체 요청 시 잔액이 부족해 부족한 금액을 충전하고 송금한다.")
@@ -266,19 +267,19 @@ public class AccountServiceTest {
                 receiverAccountd);
 
             Account account = mock(Account.class);
-            given(accountRepository.findAccountByMemberId(memberId)).willReturn(Optional.of(account));
+            given(accountRepository.findAccountByMemberId(memberId, Type.REGULAR_ACCOUNT)).willReturn(Optional.of(account));
 
             Account otherAccount = mock(Account.class);
             given(account.getBalance()).willReturn(balance);
-            given(accountRepository.findByOtherAccount(requestDto.receiverAccountId())).willReturn(
+            given(accountRepository.findAccountById(requestDto.receiverAccountId())).willReturn(
                 Optional.of(otherAccount));
 
             // when
             accountService.transferToOtherAccount(requestDto);
 
             // then
-            then(accountRepository).should(times(2)).findAccountByMemberId(memberId);
-            then(accountRepository).should(times(1)).findByOtherAccount(requestDto.receiverAccountId());
+            then(accountRepository).should(times(2)).findAccountByMemberId(memberId, Type.REGULAR_ACCOUNT);
+            then(accountRepository).should(times(1)).findAccountById(requestDto.receiverAccountId());
         }
 
         @DisplayName("친구의 계좌가 존재하지 않거나 잘못 입력해 실패한다.")
@@ -291,11 +292,11 @@ public class AccountServiceTest {
                 receiverAccountd);
 
             Account account = mock(Account.class);
-            given(accountRepository.findAccountByMemberId(memberId)).willReturn(Optional.of(account));
+            given(accountRepository.findAccountByMemberId(memberId, Type.REGULAR_ACCOUNT)).willReturn(Optional.of(account));
             given(account.getBalance()).willReturn(balance);
 
             BaseException baseException = ErrorCode.ACCOUNT_DOES_NOT_EXIST.baseException("계좌가 존재하지 않습니다.");
-            given(accountRepository.findByOtherAccount(requestDto.receiverAccountId())).willThrow(baseException);
+            given(accountRepository.findAccountById(requestDto.receiverAccountId())).willThrow(baseException);
 
             // when
             Exception exception = assertThrows(BaseException.class,

--- a/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.c4marathon.assignment.account.dto.request.RechargeAccountRequestDto;
-import org.c4marathon.assignment.account.dto.request.SavingAccountRequestDto;
+import org.c4marathon.assignment.account.dto.request.TransferToSavingAccountRequestDto;
 import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
 import org.c4marathon.assignment.account.entity.Account;
 import org.c4marathon.assignment.account.repository.AccountRepository;
@@ -147,7 +147,7 @@ public class AccountServiceTest {
             Long receiverAccountd = 3L;
             Account regularAccount = mock(Account.class);
             Account savingAccount = mock(Account.class);
-            SavingAccountRequestDto requestDto = new SavingAccountRequestDto(balance, receiverAccountd);
+            TransferToSavingAccountRequestDto requestDto = new TransferToSavingAccountRequestDto(balance, receiverAccountd);
 
             given(regularAccount.getBalance()).willReturn(balance);
             given(accountRepository.findByRegularAccount(memberId)).willReturn(Optional.of(regularAccount));
@@ -169,7 +169,7 @@ public class AccountServiceTest {
 
             // given
             Account regularAccount = mock(Account.class);
-            SavingAccountRequestDto requestDto = new SavingAccountRequestDto(balance, accountId);
+            TransferToSavingAccountRequestDto requestDto = new TransferToSavingAccountRequestDto(balance, accountId);
 
             given(regularAccount.getBalance()).willReturn(0L);
             given(accountRepository.findByRegularAccount(memberId)).willReturn(Optional.of(regularAccount));

--- a/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
@@ -14,7 +14,6 @@ import org.c4marathon.assignment.account.dto.request.RechargeAccountRequestDto;
 import org.c4marathon.assignment.account.dto.request.TransferToOtherAccountRequestDto;
 import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
 import org.c4marathon.assignment.account.entity.Account;
-import org.c4marathon.assignment.account.entity.SavingAccount;
 import org.c4marathon.assignment.account.entity.Type;
 import org.c4marathon.assignment.account.repository.AccountRepository;
 import org.c4marathon.assignment.account.repository.SavingAccountRepository;

--- a/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
@@ -15,6 +15,7 @@ import org.c4marathon.assignment.account.dto.request.SavingAccountRequestDto;
 import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
 import org.c4marathon.assignment.account.entity.Account;
 import org.c4marathon.assignment.account.repository.AccountRepository;
+import org.c4marathon.assignment.auth.service.SecurityService;
 import org.c4marathon.assignment.util.exceptions.BaseException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -33,6 +34,9 @@ public class AccountServiceTest {
 
     @InjectMocks
     private AccountService accountService;
+
+    @Mock
+    private SecurityService securityService;
 
     @Mock
     private AccountRepository accountRepository;
@@ -64,9 +68,8 @@ public class AccountServiceTest {
             List<Account> accountList = List.of(mock(Account.class), mock(Account.class));
             Authentication authentication = mock(Authentication.class);
 
-            given(authentication.getPrincipal()).willReturn(memberId);
             SecurityContextHolder.getContext().setAuthentication(authentication);
-            given(accountService.findMember()).willReturn(memberId);
+            given(securityService.findMember()).willReturn(memberId);
             given(accountRepository.findByMemberId(memberId)).willReturn(accountList);
 
             // when
@@ -90,7 +93,7 @@ public class AccountServiceTest {
         @BeforeEach
         void setUp() {
             Authentication authentication = mock(Authentication.class);
-            given(authentication.getPrincipal()).willReturn(memberId);
+            given(securityService.findMember()).willReturn(memberId);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 

--- a/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
@@ -9,7 +9,7 @@ import static org.mockito.BDDMockito.*;
 import java.util.Optional;
 
 import org.c4marathon.assignment.account.dto.request.RechargeAccountRequestDto;
-import org.c4marathon.assignment.account.dto.request.TransferToSavingAccountRequestDto;
+import org.c4marathon.assignment.account.dto.request.TransferToOtherAccountRequestDto;
 import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
 import org.c4marathon.assignment.account.entity.Account;
 import org.c4marathon.assignment.account.entity.SavingAccount;
@@ -130,7 +130,7 @@ public class AccountServiceTest {
             Account account = mock(Account.class);
             RechargeAccountRequestDto requestDto = new RechargeAccountRequestDto(accountId, balance);
 
-            given(accountRepository.findByRegularAccount(memberId)).willReturn(Optional.of(account));
+            given(accountRepository.findByAccount(memberId)).willReturn(Optional.of(account));
             given(account.getDailyLimit()).willReturn(0);
             given(account.getBalance()).willReturn(0L);
 
@@ -151,7 +151,7 @@ public class AccountServiceTest {
             Account account = mock(Account.class);
             RechargeAccountRequestDto requestDto = new RechargeAccountRequestDto(accountId, balance);
 
-            given(accountRepository.findByRegularAccount(memberId)).willReturn(Optional.of(account));
+            given(accountRepository.findByAccount(memberId)).willReturn(Optional.of(account));
             given(account.getDailyLimit()).willReturn(DAILY_LIMIT);
             given(account.getBalance()).willReturn(0L);
 
@@ -170,11 +170,11 @@ public class AccountServiceTest {
             Long receiverAccountd = 3L;
             Account regularAccount = mock(Account.class);
             SavingAccount savingAccount = mock(SavingAccount.class);
-            TransferToSavingAccountRequestDto requestDto = new TransferToSavingAccountRequestDto(balance,
+            TransferToOtherAccountRequestDto requestDto = new TransferToOtherAccountRequestDto(balance,
                 receiverAccountd);
 
             given(regularAccount.getBalance()).willReturn(balance);
-            given(accountRepository.findByRegularAccount(memberId)).willReturn(Optional.of(regularAccount));
+            given(accountRepository.findByAccount(memberId)).willReturn(Optional.of(regularAccount));
             given(savingAccountRepository.findBySavingAccount(memberId, requestDto.receiverAccountId())).willReturn(
                 Optional.of(savingAccount));
 
@@ -182,7 +182,7 @@ public class AccountServiceTest {
             accountService.transferFromRegularAccount(requestDto);
 
             // then
-            then(accountRepository).should(times(1)).findByRegularAccount(memberId);
+            then(accountRepository).should(times(1)).findByAccount(memberId);
             then(savingAccountRepository).should(times(1))
                 .findBySavingAccount(memberId, requestDto.receiverAccountId());
         }
@@ -193,10 +193,10 @@ public class AccountServiceTest {
 
             // given
             Account regularAccount = mock(Account.class);
-            TransferToSavingAccountRequestDto requestDto = new TransferToSavingAccountRequestDto(balance, accountId);
+            TransferToOtherAccountRequestDto requestDto = new TransferToOtherAccountRequestDto(balance, accountId);
 
             given(regularAccount.getBalance()).willReturn(0L);
-            given(accountRepository.findByRegularAccount(memberId)).willReturn(Optional.of(regularAccount));
+            given(accountRepository.findByAccount(memberId)).willReturn(Optional.of(regularAccount));
 
             // when
             Exception exception = assertThrows(BaseException.class,

--- a/src/test/java/org/c4marathon/assignment/account/service/SavingAccountServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/SavingAccountServiceTest.java
@@ -1,0 +1,120 @@
+package org.c4marathon.assignment.account.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.c4marathon.assignment.account.dto.request.AccountRequestDto;
+import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
+import org.c4marathon.assignment.account.dto.response.SavingAccountResponseDto;
+import org.c4marathon.assignment.account.entity.SavingAccount;
+import org.c4marathon.assignment.account.entity.Type;
+import org.c4marathon.assignment.account.repository.SavingAccountRepository;
+import org.c4marathon.assignment.auth.service.SecurityService;
+import org.c4marathon.assignment.member.entity.Member;
+import org.c4marathon.assignment.member.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class SavingAccountServiceTest {
+
+    @InjectMocks
+    private SavingAccountService savingAccountService;
+
+    @Mock
+    private SecurityService securityService;
+
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private SavingAccountRepository savingAccountRepository;
+
+    @Mock
+    private AccountService accountService;
+
+    @Nested
+    @DisplayName("적금 계좌 생성 테스트")
+    class Create {
+        @DisplayName("적금 계좌를 생성한다.")
+        @Test
+        void createMainAccountTest() {
+            // given
+            Long memberId = 0L;
+            Member member = mock(Member.class);
+            SavingAccount savingAccount = mock(SavingAccount.class);
+            AccountRequestDto accountRequestDto = new AccountRequestDto(Type.INSTALLMENT_SAVINGS_ACCOUNT);
+
+            given(securityService.findMember()).willReturn(memberId);
+            given(memberService.getMemberById(memberId)).willReturn(member);
+            given(savingAccountRepository.save(any(SavingAccount.class))).willReturn(savingAccount);
+            given(accountService.isMainAccount(memberId)).willReturn(true);
+
+            // when
+            savingAccountService.saveSavingAccount(accountRequestDto);
+
+            // then
+            then(securityService).should(times(1)).findMember();
+            then(memberService).should(times(1)).getMemberById(memberId);
+            then(savingAccountRepository).should(times(1)).save(any(SavingAccount.class));
+            then(accountService).should(times(1)).isMainAccount(memberId);
+        }
+
+        @DisplayName("적금 계좌를 생성할 때 메인 계좌가 없다면 함께 생성해준다.")
+        @Test
+        void createMainAccountAndMainAccountTest() {
+            // given
+            Long memberId = 0L;
+            Member member = mock(Member.class);
+            SavingAccount savingAccount = mock(SavingAccount.class);
+            AccountRequestDto accountRequestDto = new AccountRequestDto(Type.INSTALLMENT_SAVINGS_ACCOUNT);
+
+            given(securityService.findMember()).willReturn(memberId);
+            given(memberService.getMemberById(memberId)).willReturn(member);
+            given(savingAccountRepository.save(any(SavingAccount.class))).willReturn(savingAccount);
+            given(accountService.isMainAccount(memberId)).willReturn(false);
+            willDoNothing().given(accountService).saveMainAccount(memberId);
+
+            // when
+            savingAccountService.saveSavingAccount(accountRequestDto);
+
+            // then
+            then(securityService).should(times(1)).findMember();
+            then(memberService).should(times(1)).getMemberById(memberId);
+            then(savingAccountRepository).should(times(1)).save(any(SavingAccount.class));
+            then(accountService).should(times(1)).isMainAccount(memberId);
+            then(accountService).should(times(1)).saveMainAccount(memberId);
+        }
+    }
+
+    @Nested
+    @DisplayName("계좌 조회 테스트")
+    class Read {
+        @DisplayName("계좌 조회를 위해 회원의 정보를 조회하고, 회원의 메인 계좌 정보를 불러온다.")
+        @Test
+        void findSavingAccountTest() {
+            // given
+            Long memberId = 0L;
+            SavingAccount savingAccount = mock(SavingAccount.class);
+            AccountResponseDto accountResponseDto = mock(AccountResponseDto.class);
+            given(securityService.findMember()).willReturn(memberId);
+            given(savingAccountRepository.findByMemberId(memberId)).willReturn(List.of(savingAccount));
+
+            // when
+            List<SavingAccountResponseDto> savingAccountResponseDtoList = savingAccountService.findSavingAccount();
+
+            // then
+            then(securityService).should(times(1)).findMember();
+            then(savingAccountRepository).should(times(1)).findByMemberId(memberId);
+            assertEquals(savingAccountResponseDtoList.get(0).id(), accountResponseDto.id());
+        }
+    }
+}

--- a/src/test/java/org/c4marathon/assignment/auth/service/SecurityServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/auth/service/SecurityServiceTest.java
@@ -14,7 +14,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 @ExtendWith(MockitoExtension.class)
-public class SecurityServiceTest {
+class SecurityServiceTest {
 
     @InjectMocks
     private SecurityService securityService;

--- a/src/test/java/org/c4marathon/assignment/auth/service/SecurityServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/auth/service/SecurityServiceTest.java
@@ -1,0 +1,42 @@
+package org.c4marathon.assignment.auth.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+public class SecurityServiceTest {
+
+    @InjectMocks
+    private SecurityService securityService;
+
+    @Mock
+    private Authentication authentication;
+
+    @BeforeEach
+    void setUp() {
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @DisplayName("SecurityContextHolder에 등록되어 있는 회원의 정보를 찾아온다.")
+    @Test
+    void findMemberTest() {
+        // given
+        long memberId = 0L;
+        given(authentication.getPrincipal()).willReturn(memberId);
+        // when
+        when(securityService.findMember()).thenReturn(memberId);
+        long resultMemberId = securityService.findMember();
+        // then
+        assertEquals(memberId, resultMemberId);
+    }
+}


### PR DESCRIPTION
## 도메인 변경(Account -> Account, SavingAccount)
![image](https://github.com/C4-ComeTrue/c4-cometrue-assignment/assets/87405853/aaebf11e-e364-4316-a419-c31ee0d2c05a)

- 이후 적금 계좌에 이자를 추가해주기 위해 Batch의 사용을 고민하고 있습니다. 이전 방식은 Batch를 사용할 때 적합하지 않고, 성능이 저하될 것을 고려해 변경해주었습니다.
- 또한 적금 계좌엔 DailyLimit가 존재하지 않기 때문에 변경해주었습니다.

## SecurityService
- 현재 Security에서 addFilterBefore를 통해 permitAll 설정을 제외한 모든 부분에서 토큰 검증 로직을 수행하고, SecurityContextHolder.getContext().setAuthentication(authenticationToken);을 통해 스레드 로컬에 인증 정보를 저장하여 사용하고 있습니다. 
  - 모든 서비스(Service)에서 findMember 메소드를 호출하여 토큰 검증 로직을 수행하는 것은 단일 책임 원칙에 어긋난다고 판단되어, 이를 분리하기 위해 SecurityService를 작성하였습니다.

## 송금 기능
- 송금 기능을 작성할 때 돈이 부족한 상황을 가정하여 외부에서 메인 계좌로 입금하는 로직을 사용하는 것을 고려해야 했습니다.
  - 이는 하나의 트랜잭션에서 실행되지만, 실제로는 트랜잭션을 2개를 처리해야 합니다. 이를 스프링에서는 실제 DB에 연결되는 물리 트랜잭션과 스프링이 처리하는 논리 트랜잭션으로 구분하여 처리한다는 것을 알게 되었습니다.
  - 모든 논리 트랜잭션이 성공해야 물리 트랜잭션이 커밋되고, 논리 트랜잭션이 하나라도 실패하면 롤백되게 됩니다.
- 타 계좌로 송금하는 기능을 만들었습니다. 이때, 적금 계좌로의 송금은 불가능 합니다. (적금 계좌로 송금은 메인 계좌에 돈이 부족할 시 송금 불가)
  - 적금 계좌로 송금하는 기능보다 해당 기능이 충돌이 발생할 가능성이 있지만, 티켓 예매와 같이 동시에 많은 트래픽이 발생하는 기능들보다 충돌 가능성이 많지는 않습니다. 해당 과정에서 JPA의 Save 메서드의 Dirty Checking이 아닌 직접 Update Query를 통해 DB에 값을 변경해주는 테스트에 성공했습니다. 하지만, 이후에 정산하기 기능을 추가할 때 동시성 문제가 발생할 수 있어 발생할 것이라는 생각에 비관적 잠금을 그대로 적용해주었습니다.
    - 혹시 이 정도면 충돌 가능성이 적다고 판단되어 방법을 Update Query를 통한 방법으로 변경해주어야 할까요?
 
## 일일 한도 관리
- 이전까지는 Daily_Limit Column을 만들어주고 초기화 하는 로직은 적용하지 않았습니다. 이전까지는 Batch를 사용하여 매일 00시에 초기화하는 로직을 추가시키는 방법과 Redis의 TTL 기능을 고민했지만, 계좌를 이용하지 않는 사람들을 매번 초기화해줄 필요는 없다는 생각이 들었습니다. 
  - 그래서 입금 로직이 요청되었을 때 마지막 입금 날짜와 다르다면 초기화하는 방식을 적용해주었습니다.