### PR TITLE
Feature/kariskan step3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,11 +58,10 @@ jacocoTestReport {
 
 sonar {
     properties {
-//        property "sonar.projectKey", "C4-ComeTrue_c4-cometrue-assignment"
-//        property "sonar.organization", "c4-cometrue"
-        property "sonar.host.url", "http://localhost:9000"
-        property "sonar.token", "squ_8328e6c4e109383c558fcf98fa833401cdf61146"
-//        property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml"
-//        property "sonar.java.checkstyle.reportPaths", "build/reports/checkstyle/main.xml"
+        property "sonar.projectKey", "C4-ComeTrue_c4-cometrue-assignment"
+        property "sonar.organization", "c4-cometrue"
+        property "sonar.host.url", "https://sonarcloud.io"
+        property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml"
+        property "sonar.java.checkstyle.reportPaths", "build/reports/checkstyle/main.xml"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.apache.commons:commons-lang3:3.13.0'
     implementation 'org.apache.commons:commons-collections4:4.4'
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -57,10 +58,11 @@ jacocoTestReport {
 
 sonar {
     properties {
-        property "sonar.projectKey", "C4-ComeTrue_c4-cometrue-assignment"
-        property "sonar.organization", "c4-cometrue"
-        property "sonar.host.url", "https://sonarcloud.io"
-        property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml"
-        property "sonar.java.checkstyle.reportPaths", "build/reports/checkstyle/main.xml"
+//        property "sonar.projectKey", "C4-ComeTrue_c4-cometrue-assignment"
+//        property "sonar.organization", "c4-cometrue"
+        property "sonar.host.url", "http://localhost:9000"
+        property "sonar.token", "squ_8328e6c4e109383c558fcf98fa833401cdf61146"
+//        property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml"
+//        property "sonar.java.checkstyle.reportPaths", "build/reports/checkstyle/main.xml"
     }
 }

--- a/src/main/java/org/c4marathon/assignment/domain/consumer/service/ConsumerService.java
+++ b/src/main/java/org/c4marathon/assignment/domain/consumer/service/ConsumerService.java
@@ -107,8 +107,16 @@ public class ConsumerService {
 		order.updateOrderStatus(CONFIRM);
 		List<OrderProduct> orderProducts = orderProductReadService.findByOrderJoinFetchProductAndSeller(orderId);
 		addSellerBalance(orderProducts);
+		addOrderCount(orderProducts);
 
 		savePointLog(consumer, order, true);
+	}
+
+	/**
+	 * 주문 시 product에 대한 구매 횟수를 증가함
+	 */
+	private void addOrderCount(List<OrderProduct> orderProducts) {
+		orderProducts.forEach(orderProduct -> orderProduct.getProduct().increaseOrderCount());
 	}
 
 	private void saveOrderInfo(PurchaseProductRequest request, Consumer consumer, Order order,

--- a/src/main/java/org/c4marathon/assignment/domain/deliverycompany/service/DeliveryCompanyService.java
+++ b/src/main/java/org/c4marathon/assignment/domain/deliverycompany/service/DeliveryCompanyService.java
@@ -54,7 +54,7 @@ public class DeliveryCompanyService {
 	 */
 	private boolean isInvalidChangeStatus(DeliveryStatus future, DeliveryStatus current) {
 		return future.isPending()
-			|| (future.isDelivering() && !current.isPending())
-			|| (future.isDelivered() && !current.isDelivering());
+			   || (future.isDelivering() && !current.isPending())
+			   || (future.isDelivered() && !current.isDelivering());
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/domain/order/repository/OrderRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/order/repository/OrderRepository.java
@@ -1,7 +1,11 @@
 package org.c4marathon.assignment.domain.order.repository;
 
+import java.util.List;
+
 import org.c4marathon.assignment.domain.order.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
+
+	boolean existsByConsumerIdAndIdIn(Long consumerId, List<Long> ids);
 }

--- a/src/main/java/org/c4marathon/assignment/domain/orderproduct/entity/OrderProduct.java
+++ b/src/main/java/org/c4marathon/assignment/domain/orderproduct/entity/OrderProduct.java
@@ -10,6 +10,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -20,7 +21,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "order_product_tbl")
+@Table(
+	name = "order_product_tbl",
+	indexes = {
+		@Index(name = "created_at_idx", columnList = "created_at")
+	}
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class OrderProduct extends BaseEntity {

--- a/src/main/java/org/c4marathon/assignment/domain/orderproduct/repository/OrderProductRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/orderproduct/repository/OrderProductRepository.java
@@ -1,9 +1,11 @@
 package org.c4marathon.assignment.domain.orderproduct.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.c4marathon.assignment.domain.orderproduct.entity.OrderProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -17,4 +19,13 @@ public interface OrderProductRepository extends JpaRepository<OrderProduct, Long
 
 	@Query(value = "select order_id from order_product_tbl op where op.product_id = :product_id", nativeQuery = true)
 	List<Long> findOrderIdByProductId(@Param("product_id") Long id);
+
+	@Modifying
+	@Query(value = """
+		delete
+		from order_product_tbl op
+		where op.created_at <= :dateTime
+		limit :pageSize
+		""", nativeQuery = true)
+	int deleteOrderProductTable(@Param("dateTime") LocalDateTime dateTime, @Param("pageSize") int pageSize);
 }

--- a/src/main/java/org/c4marathon/assignment/domain/orderproduct/repository/OrderProductRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/orderproduct/repository/OrderProductRepository.java
@@ -14,4 +14,15 @@ public interface OrderProductRepository extends JpaRepository<OrderProduct, Long
 
 	@Query("select op from OrderProduct op join fetch op.product join fetch op.product.seller where op.order.id = :id")
 	List<OrderProduct> findByOrderJoinFetchProductAndSeller(@Param("id") Long orderId);
+
+	@Query(value = "select order_id from order_product_tbl op where op.product_id = :product_id", nativeQuery = true)
+	List<Long> findOrderIdByProductId(@Param("product_id") Long id);
+
+	@Query(value = """
+		select count(*)
+		from order_tbl o
+		where consumer_id = :consumer_id
+		  and order_id in (:ids)
+		""", nativeQuery = true)
+	Long countByIdsAndConsumerId(@Param("ids") List<Long> ids, @Param("consumer_id") Long consumerId);
 }

--- a/src/main/java/org/c4marathon/assignment/domain/orderproduct/repository/OrderProductRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/orderproduct/repository/OrderProductRepository.java
@@ -17,12 +17,4 @@ public interface OrderProductRepository extends JpaRepository<OrderProduct, Long
 
 	@Query(value = "select order_id from order_product_tbl op where op.product_id = :product_id", nativeQuery = true)
 	List<Long> findOrderIdByProductId(@Param("product_id") Long id);
-
-	@Query(value = """
-		select count(*)
-		from order_tbl o
-		where consumer_id = :consumer_id
-		  and order_id in (:ids)
-		""", nativeQuery = true)
-	Long countByIdsAndConsumerId(@Param("ids") List<Long> ids, @Param("consumer_id") Long consumerId);
 }

--- a/src/main/java/org/c4marathon/assignment/domain/orderproduct/service/OrderProductReadService.java
+++ b/src/main/java/org/c4marathon/assignment/domain/orderproduct/service/OrderProductReadService.java
@@ -2,6 +2,7 @@ package org.c4marathon.assignment.domain.orderproduct.service;
 
 import java.util.List;
 
+import org.c4marathon.assignment.domain.order.repository.OrderRepository;
 import org.c4marathon.assignment.domain.orderproduct.entity.OrderProduct;
 import org.c4marathon.assignment.domain.orderproduct.repository.OrderProductRepository;
 import org.springframework.stereotype.Service;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 public class OrderProductReadService {
 
 	private final OrderProductRepository orderProductRepository;
+	private final OrderRepository orderRepository;
 
 	/**
 	 * Product와 조인한 OrderProduct list를 orderId로 조회
@@ -37,6 +39,6 @@ public class OrderProductReadService {
 	@Transactional(readOnly = true)
 	public boolean existsByConsumerIdAndProductId(Long consumerId, Long productId) {
 		List<Long> orderIds = orderProductRepository.findOrderIdByProductId(productId);
-		return orderProductRepository.countByIdsAndConsumerId(orderIds, consumerId) > 0;
+		return orderRepository.existsByConsumerIdAndIdIn(consumerId, orderIds);
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/domain/orderproduct/service/OrderProductReadService.java
+++ b/src/main/java/org/c4marathon/assignment/domain/orderproduct/service/OrderProductReadService.java
@@ -30,4 +30,13 @@ public class OrderProductReadService {
 	public List<OrderProduct> findByOrderJoinFetchProductAndSeller(Long orderId) {
 		return orderProductRepository.findByOrderJoinFetchProductAndSeller(orderId);
 	}
+
+	/**
+	 * consumer id와 product id로 구매 이력 조회
+	 */
+	@Transactional(readOnly = true)
+	public boolean existsByConsumerIdAndProductId(Long consumerId, Long productId) {
+		List<Long> orderIds = orderProductRepository.findOrderIdByProductId(productId);
+		return orderProductRepository.countByIdsAndConsumerId(orderIds, consumerId) > 0;
+	}
 }

--- a/src/main/java/org/c4marathon/assignment/domain/product/controller/ProductController.java
+++ b/src/main/java/org/c4marathon/assignment/domain/product/controller/ProductController.java
@@ -1,0 +1,27 @@
+package org.c4marathon.assignment.domain.product.controller;
+
+import org.c4marathon.assignment.domain.product.dto.request.ProductSearchRequest;
+import org.c4marathon.assignment.domain.product.dto.response.ProductSearchResponse;
+import org.c4marathon.assignment.domain.product.service.ProductReadService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/products")
+public class ProductController {
+
+	private final ProductReadService productReadService;
+
+	@GetMapping
+	public ProductSearchResponse searchProduct(
+		@Valid @ModelAttribute ProductSearchRequest request
+	) {
+		return productReadService.searchProduct(request);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/product/dto/request/ProductSearchRequest.java
+++ b/src/main/java/org/c4marathon/assignment/domain/product/dto/request/ProductSearchRequest.java
@@ -11,11 +11,11 @@ import lombok.Builder;
 public record ProductSearchRequest(
 	@NotNull @Size(min = 2, message = "keyword length less than 2") String keyword,
 	@NotNull SortType sortType,
-	LocalDateTime lastCreatedAt,
-	Long lastProductId,
-	Long lastAmount,
-	Long lastOrderCount,
-	Double lastScore,
+	LocalDateTime createdAt,
+	Long productId,
+	Long amount,
+	Long orderCount,
+	Double score,
 	int pageSize
 ) {
 
@@ -23,20 +23,20 @@ public record ProductSearchRequest(
 	public ProductSearchRequest(
 		String keyword,
 		SortType sortType,
-		LocalDateTime lastCreatedAt,
-		Long lastProductId,
-		Long lastAmount,
-		Long lastOrderCount,
-		Double lastScore,
+		LocalDateTime createdAt,
+		Long productId,
+		Long amount,
+		Long orderCount,
+		Double score,
 		int pageSize
 	) {
 		this.keyword = keyword;
 		this.sortType = sortType;
-		this.lastCreatedAt = setDefaultValue(lastCreatedAt, LocalDateTime.now());
-		this.lastProductId = setDefaultValue(lastProductId, 0L);
-		this.lastAmount = setDefaultValue(lastAmount, getDefaultLastAmount(sortType));
-		this.lastOrderCount = setDefaultValue(lastOrderCount, Long.MAX_VALUE);
-		this.lastScore = setDefaultValue(lastScore, 5.0);
+		this.createdAt = setDefaultValue(createdAt, LocalDateTime.now());
+		this.productId = setDefaultValue(productId, 0L);
+		this.amount = setDefaultValue(amount, getDefaultAmount(sortType));
+		this.orderCount = setDefaultValue(orderCount, Long.MAX_VALUE);
+		this.score = setDefaultValue(score, 5.0);
 		this.pageSize = pageSize;
 	}
 
@@ -44,7 +44,7 @@ public record ProductSearchRequest(
 		return value != null ? value : defaultValue;
 	}
 
-	private Long getDefaultLastAmount(SortType sortType) {
+	private Long getDefaultAmount(SortType sortType) {
 		return sortType == SortType.PRICE_ASC ? 0L : Long.MAX_VALUE;
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/domain/product/dto/request/ProductSearchRequest.java
+++ b/src/main/java/org/c4marathon/assignment/domain/product/dto/request/ProductSearchRequest.java
@@ -45,6 +45,6 @@ public record ProductSearchRequest(
 	}
 
 	private Long getDefaultLastAmount(SortType sortType) {
-		return sortType == SortType.PriceAsc ? 0L : Long.MAX_VALUE;
+		return sortType == SortType.PRICE_ASC ? 0L : Long.MAX_VALUE;
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/domain/product/dto/request/ProductSearchRequest.java
+++ b/src/main/java/org/c4marathon/assignment/domain/product/dto/request/ProductSearchRequest.java
@@ -1,0 +1,50 @@
+package org.c4marathon.assignment.domain.product.dto.request;
+
+import java.time.LocalDateTime;
+
+import org.c4marathon.assignment.global.constant.SortType;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+public record ProductSearchRequest(
+	@NotNull @Size(min = 2, message = "keyword length less than 2") String keyword,
+	@NotNull SortType sortType,
+	LocalDateTime lastCreatedAt,
+	Long lastProductId,
+	Long lastAmount,
+	Long lastOrderCount,
+	Double lastScore,
+	int pageSize
+) {
+
+	@Builder
+	public ProductSearchRequest(
+		String keyword,
+		SortType sortType,
+		LocalDateTime lastCreatedAt,
+		Long lastProductId,
+		Long lastAmount,
+		Long lastOrderCount,
+		Double lastScore,
+		int pageSize
+	) {
+		this.keyword = keyword;
+		this.sortType = sortType;
+		this.lastCreatedAt = setDefaultValue(lastCreatedAt, LocalDateTime.now());
+		this.lastProductId = setDefaultValue(lastProductId, 0L);
+		this.lastAmount = setDefaultValue(lastAmount, getDefaultLastAmount(sortType));
+		this.lastOrderCount = setDefaultValue(lastOrderCount, Long.MAX_VALUE);
+		this.lastScore = setDefaultValue(lastScore, 5.0);
+		this.pageSize = pageSize;
+	}
+
+	private <T> T setDefaultValue(T value, T defaultValue) {
+		return value != null ? value : defaultValue;
+	}
+
+	private Long getDefaultLastAmount(SortType sortType) {
+		return sortType == SortType.PriceAsc ? 0L : Long.MAX_VALUE;
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/product/dto/request/ProductSearchRequest.java
+++ b/src/main/java/org/c4marathon/assignment/domain/product/dto/request/ProductSearchRequest.java
@@ -33,10 +33,10 @@ public record ProductSearchRequest(
 		this.keyword = keyword;
 		this.sortType = sortType;
 		this.createdAt = setDefaultValue(createdAt, LocalDateTime.now());
-		this.productId = setDefaultValue(productId, 0L);
+		this.productId = setDefaultValue(productId, Long.MIN_VALUE);
 		this.amount = setDefaultValue(amount, getDefaultAmount(sortType));
 		this.orderCount = setDefaultValue(orderCount, Long.MAX_VALUE);
-		this.score = setDefaultValue(score, 5.0);
+		this.score = setDefaultValue(score, Double.MAX_VALUE);
 		this.pageSize = pageSize;
 	}
 
@@ -45,6 +45,6 @@ public record ProductSearchRequest(
 	}
 
 	private Long getDefaultAmount(SortType sortType) {
-		return sortType == SortType.PRICE_ASC ? 0L : Long.MAX_VALUE;
+		return sortType == SortType.PRICE_ASC ? Long.MIN_VALUE : Long.MAX_VALUE;
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/domain/product/dto/request/ProductSearchRequest.java
+++ b/src/main/java/org/c4marathon/assignment/domain/product/dto/request/ProductSearchRequest.java
@@ -1,5 +1,7 @@
 package org.c4marathon.assignment.domain.product.dto.request;
 
+import static java.util.Objects.*;
+
 import java.time.LocalDateTime;
 
 import org.c4marathon.assignment.global.constant.SortType;
@@ -32,16 +34,12 @@ public record ProductSearchRequest(
 	) {
 		this.keyword = keyword;
 		this.sortType = sortType;
-		this.createdAt = setDefaultValue(createdAt, LocalDateTime.now());
-		this.productId = setDefaultValue(productId, Long.MIN_VALUE);
-		this.amount = setDefaultValue(amount, getDefaultAmount(sortType));
-		this.orderCount = setDefaultValue(orderCount, Long.MAX_VALUE);
-		this.score = setDefaultValue(score, Double.MAX_VALUE);
+		this.createdAt = requireNonNullElse(createdAt, LocalDateTime.now());
+		this.productId = requireNonNullElse(productId, Long.MIN_VALUE);
+		this.amount = requireNonNullElse(amount, getDefaultAmount(sortType));
+		this.orderCount = requireNonNullElse(orderCount, Long.MAX_VALUE);
+		this.score = requireNonNullElse(score, Double.MAX_VALUE);
 		this.pageSize = pageSize;
-	}
-
-	private <T> T setDefaultValue(T value, T defaultValue) {
-		return value != null ? value : defaultValue;
 	}
 
 	private Long getDefaultAmount(SortType sortType) {

--- a/src/main/java/org/c4marathon/assignment/domain/product/dto/response/ProductSearchEntry.java
+++ b/src/main/java/org/c4marathon/assignment/domain/product/dto/response/ProductSearchEntry.java
@@ -1,0 +1,15 @@
+package org.c4marathon.assignment.domain.product.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ProductSearchEntry(
+	long id,
+	String name,
+	String description,
+	long amount,
+	int stock,
+	LocalDateTime createdAt,
+	Long orderCount,
+	Double avgScore
+) {
+}

--- a/src/main/java/org/c4marathon/assignment/domain/product/dto/response/ProductSearchResponse.java
+++ b/src/main/java/org/c4marathon/assignment/domain/product/dto/response/ProductSearchResponse.java
@@ -1,0 +1,23 @@
+package org.c4marathon.assignment.domain.product.dto.response;
+
+import java.util.List;
+
+import org.c4marathon.assignment.domain.product.entity.Product;
+
+public record ProductSearchResponse(
+	List<ProductSearchEntry> productSearchEntries
+) {
+	public static ProductSearchResponse of(List<Product> products) {
+		return new ProductSearchResponse(products.stream()
+			.map(product -> new ProductSearchEntry(
+				product.getId(),
+				product.getName(),
+				product.getDescription(),
+				product.getAmount(),
+				product.getStock(),
+				product.getCreatedAt(),
+				product.getOrderCount(),
+				product.getAvgScore()))
+			.toList());
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/product/dto/response/ProductSearchResponse.java
+++ b/src/main/java/org/c4marathon/assignment/domain/product/dto/response/ProductSearchResponse.java
@@ -2,22 +2,7 @@ package org.c4marathon.assignment.domain.product.dto.response;
 
 import java.util.List;
 
-import org.c4marathon.assignment.domain.product.entity.Product;
-
 public record ProductSearchResponse(
 	List<ProductSearchEntry> productSearchEntries
 ) {
-	public static ProductSearchResponse of(List<Product> products) {
-		return new ProductSearchResponse(products.stream()
-			.map(product -> new ProductSearchEntry(
-				product.getId(),
-				product.getName(),
-				product.getDescription(),
-				product.getAmount(),
-				product.getStock(),
-				product.getCreatedAt(),
-				product.getOrderCount(),
-				product.getAvgScore()))
-			.toList());
-	}
 }

--- a/src/main/java/org/c4marathon/assignment/domain/product/entity/Product.java
+++ b/src/main/java/org/c4marathon/assignment/domain/product/entity/Product.java
@@ -32,7 +32,7 @@ import lombok.NoArgsConstructor;
 		@Index(name = "amount_product_id_idx", columnList = "amount, product_id"),
 		@Index(name = "amount_desc_product_id_idx", columnList = "amount desc, product_id"),
 		@Index(name = "created_at_product_id_idx", columnList = "created_at desc, product_id"),
-		@Index(name = "avg_score_desc_product_id_idx", columnList = "avg_score desc, product_id asc"),
+		@Index(name = "avg_score_desc_product_id_idx", columnList = "avg_score desc, product_id"),
 		@Index(name = "order_count_desc_product_id_idx", columnList = "order_count desc, product_id")
 	}
 )

--- a/src/main/java/org/c4marathon/assignment/domain/product/entity/Product.java
+++ b/src/main/java/org/c4marathon/assignment/domain/product/entity/Product.java
@@ -2,6 +2,8 @@ package org.c4marathon.assignment.domain.product.entity;
 
 import static org.c4marathon.assignment.global.constant.ProductStatus.*;
 
+import java.math.BigDecimal;
+
 import org.c4marathon.assignment.domain.base.entity.BaseEntity;
 import org.c4marathon.assignment.domain.seller.entity.Seller;
 import org.c4marathon.assignment.global.constant.ProductStatus;
@@ -71,7 +73,7 @@ public class Product extends BaseEntity {
 
 	@NotNull
 	@Column(name = "avg_score", columnDefinition = "DECIMAL(5, 4) DEFAULT 0.0000")
-	private Double avgScore;
+	private BigDecimal avgScore;
 
 	@NotNull
 	@Column(name = "order_count", columnDefinition = "BIGINT DEFAULT 0")
@@ -92,7 +94,7 @@ public class Product extends BaseEntity {
 		this.seller = seller;
 		this.productStatus = IN_STOCK;
 		this.orderCount = 0L;
-		this.avgScore = (double)0;
+		this.avgScore = BigDecimal.ZERO;
 	}
 
 	public void decreaseStock(Integer quantity) {
@@ -110,7 +112,7 @@ public class Product extends BaseEntity {
 		this.orderCount++;
 	}
 
-	public void updateAvgScore(Double avgScore) {
+	public void updateAvgScore(BigDecimal avgScore) {
 		this.avgScore = avgScore;
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/domain/product/entity/Product.java
+++ b/src/main/java/org/c4marathon/assignment/domain/product/entity/Product.java
@@ -28,7 +28,12 @@ import lombok.NoArgsConstructor;
 @Table(
 	name = "product_tbl",
 	indexes = {
-		@Index(name = "product_name_seller_id_idx", columnList = "name,seller_id")
+		@Index(name = "product_name_seller_id_idx", columnList = "name,seller_id"),
+		@Index(name = "amount_product_id_idx", columnList = "amount, product_id"),
+		@Index(name = "amount_desc_product_id_idx", columnList = "amount desc, product_id"),
+		@Index(name = "created_at_product_id_idx", columnList = "created_at desc, product_id"),
+		@Index(name = "avg_score_desc_product_id_idx", columnList = "avg_score desc, product_id asc"),
+		@Index(name = "order_count_desc_product_id_idx", columnList = "order_count desc, product_id")
 	}
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -64,6 +69,14 @@ public class Product extends BaseEntity {
 	@Column(name = "status", columnDefinition = "VARCHAR(20)")
 	private ProductStatus productStatus;
 
+	@NotNull
+	@Column(name = "avg_score", columnDefinition = "DECIMAL(5, 4) DEFAULT 0.0000")
+	private Double avgScore;
+
+	@NotNull
+	@Column(name = "order_count", columnDefinition = "BIGINT DEFAULT 0")
+	private Long orderCount;
+
 	@Builder
 	public Product(
 		String name,
@@ -78,6 +91,8 @@ public class Product extends BaseEntity {
 		this.stock = stock;
 		this.seller = seller;
 		this.productStatus = IN_STOCK;
+		this.orderCount = 0L;
+		this.avgScore = (double)0;
 	}
 
 	public void decreaseStock(Integer quantity) {
@@ -89,5 +104,13 @@ public class Product extends BaseEntity {
 
 	public boolean isSoldOut() {
 		return this.productStatus == OUT_OF_STOCK;
+	}
+
+	public void increaseOrderCount() {
+		this.orderCount++;
+	}
+
+	public void updateAvgScore(Double avgScore) {
+		this.avgScore = avgScore;
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/domain/product/repository/ProductMapper.java
+++ b/src/main/java/org/c4marathon/assignment/domain/product/repository/ProductMapper.java
@@ -1,0 +1,12 @@
+package org.c4marathon.assignment.domain.product.repository;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.c4marathon.assignment.domain.product.dto.request.ProductSearchRequest;
+import org.c4marathon.assignment.domain.product.dto.response.ProductSearchEntry;
+
+@Mapper
+public interface ProductMapper {
+	List<ProductSearchEntry> selectByCondition(ProductSearchRequest request);
+}

--- a/src/main/java/org/c4marathon/assignment/domain/product/repository/ProductRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/product/repository/ProductRepository.java
@@ -1,5 +1,7 @@
 package org.c4marathon.assignment.domain.product.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.c4marathon.assignment.domain.product.entity.Product;
@@ -18,4 +20,88 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("select p from Product p join fetch p.seller where p.id = :id")
 	Optional<Product> findByIdJoinFetch(@Param("id") Long id);
+
+	@Query(value = """
+		select count(*)
+		from product_tbl p
+		where p.product_id = :product_id
+		""", nativeQuery = true)
+	Long findReviewCount(@Param("product_id") Long id);
+
+	@Query(value = """
+		select *
+		from product_tbl p
+		where name like :keyword
+		  and (p.created_at < :createdAt or (p.created_at = :createdAt and p.product_id > :id))
+		order by p.created_at desc, p.product_id
+		limit :pageSize
+		""", nativeQuery = true)
+	List<Product> findByNewest(
+		@Param("keyword") String keyword,
+		@Param("createdAt") LocalDateTime createdAt,
+		@Param("id") Long id,
+		@Param("pageSize") int pageSize
+	);
+
+	@Query(value = """
+		select *
+		from product_tbl p
+		where name like :keyword
+		  and (p.amount > :amount or (p.amount = :amount and p.product_id > :id))
+		order by p.amount, p.product_id
+		limit :pageSize
+		""", nativeQuery = true)
+	List<Product> findByPriceAsc(
+		@Param("keyword") String keyword,
+		@Param("amount") Long amount,
+		@Param("id") Long id,
+		@Param("pageSize") int pageSize
+	);
+
+	@Query(value = """
+		select *
+		from product_tbl p
+		where (p.amount < :amount or (p.amount = :amount and p.product_id > :id))
+		  and name like :keyword
+		order by p.amount desc, p.product_id
+		limit :pageSize
+		""", nativeQuery = true)
+	List<Product> findByPriceDesc(
+		@Param("keyword") String keyword,
+		@Param("amount") Long amount,
+		@Param("id") Long id,
+		@Param("pageSize") int pageSize
+	);
+
+	@Query(value = """
+		select *
+		from product_tbl
+		where name like :keyword
+		    and order_count <= :order_count
+		   or (order_count = :order_count and product_id > :product_id)
+		order by order_count desc, product_id
+		limit :pageSize
+		""", nativeQuery = true)
+	List<Product> findByPopularity(
+		@Param("keyword") String keyword,
+		@Param("order_count") Long orderCount,
+		@Param("product_id") Long id,
+		@Param("pageSize") int pageSize
+	);
+
+	@Query(value = """
+		select *
+		from product_tbl
+		where name like :keyword
+		    and avg_score <= :avgScore
+		   or (avg_score = :avgScore and product_id > :product_id)
+		order by avg_score desc, product_id
+		limit :pageSize
+		""", nativeQuery = true)
+	List<Product> findByTopRated(
+		@Param("keyword") String keyword,
+		@Param("avgScore") Double avgScore,
+		@Param("product_id") Long id,
+		@Param("pageSize") int pageSize
+	);
 }

--- a/src/main/java/org/c4marathon/assignment/domain/product/repository/ProductRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/product/repository/ProductRepository.java
@@ -1,7 +1,5 @@
 package org.c4marathon.assignment.domain.product.repository;
 
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
 import org.c4marathon.assignment.domain.product.entity.Product;
@@ -20,88 +18,4 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("select p from Product p join fetch p.seller where p.id = :id")
 	Optional<Product> findByIdJoinFetch(@Param("id") Long id);
-
-	@Query(value = """
-		select count(*)
-		from product_tbl p
-		where p.product_id = :product_id
-		""", nativeQuery = true)
-	Long findReviewCount(@Param("product_id") Long id);
-
-	@Query(value = """
-		select *
-		from product_tbl p
-		where name like :keyword
-		  and (p.created_at < :createdAt or (p.created_at = :createdAt and p.product_id > :id))
-		order by p.created_at desc, p.product_id
-		limit :pageSize
-		""", nativeQuery = true)
-	List<Product> findByNewest(
-		@Param("keyword") String keyword,
-		@Param("createdAt") LocalDateTime createdAt,
-		@Param("id") Long id,
-		@Param("pageSize") int pageSize
-	);
-
-	@Query(value = """
-		select *
-		from product_tbl p
-		where name like :keyword
-		  and (p.amount > :amount or (p.amount = :amount and p.product_id > :id))
-		order by p.amount, p.product_id
-		limit :pageSize
-		""", nativeQuery = true)
-	List<Product> findByPriceAsc(
-		@Param("keyword") String keyword,
-		@Param("amount") Long amount,
-		@Param("id") Long id,
-		@Param("pageSize") int pageSize
-	);
-
-	@Query(value = """
-		select *
-		from product_tbl p
-		where (p.amount < :amount or (p.amount = :amount and p.product_id > :id))
-		  and name like :keyword
-		order by p.amount desc, p.product_id
-		limit :pageSize
-		""", nativeQuery = true)
-	List<Product> findByPriceDesc(
-		@Param("keyword") String keyword,
-		@Param("amount") Long amount,
-		@Param("id") Long id,
-		@Param("pageSize") int pageSize
-	);
-
-	@Query(value = """
-		select *
-		from product_tbl
-		where name like :keyword
-		    and order_count <= :order_count
-		   or (order_count = :order_count and product_id > :product_id)
-		order by order_count desc, product_id
-		limit :pageSize
-		""", nativeQuery = true)
-	List<Product> findByPopularity(
-		@Param("keyword") String keyword,
-		@Param("order_count") Long orderCount,
-		@Param("product_id") Long id,
-		@Param("pageSize") int pageSize
-	);
-
-	@Query(value = """
-		select *
-		from product_tbl
-		where name like :keyword
-		    and avg_score <= :avgScore
-		   or (avg_score = :avgScore and product_id > :product_id)
-		order by avg_score desc, product_id
-		limit :pageSize
-		""", nativeQuery = true)
-	List<Product> findByTopRated(
-		@Param("keyword") String keyword,
-		@Param("avgScore") Double avgScore,
-		@Param("product_id") Long id,
-		@Param("pageSize") int pageSize
-	);
 }

--- a/src/main/java/org/c4marathon/assignment/domain/product/service/ProductReadService.java
+++ b/src/main/java/org/c4marathon/assignment/domain/product/service/ProductReadService.java
@@ -1,5 +1,9 @@
 package org.c4marathon.assignment.domain.product.service;
 
+import java.util.List;
+
+import org.c4marathon.assignment.domain.product.dto.request.ProductSearchRequest;
+import org.c4marathon.assignment.domain.product.dto.response.ProductSearchResponse;
 import org.c4marathon.assignment.domain.product.entity.Product;
 import org.c4marathon.assignment.domain.product.repository.ProductRepository;
 import org.c4marathon.assignment.domain.seller.entity.Seller;
@@ -30,5 +34,39 @@ public class ProductReadService {
 	public Product findById(Long id) {
 		return productRepository.findByIdJoinFetch(id)
 			.orElseThrow(() -> ErrorCode.PRODUCT_NOT_FOUND.baseException("id: %d", id));
+	}
+
+	@Transactional(readOnly = true)
+	public Long findReviewCount(Long productId) {
+		return productRepository.findReviewCount(productId);
+	}
+
+	/**
+	 * sortType에 해당하는 조건으로 pagination
+	 * Newest: 최신순, created_at desc, product_id asc
+	 * PriceAsc: 가격 낮은 순, amount asc, product_id asc
+	 * PriceDesc: 가격 높은 순, amount desc, product_id asc
+	 * Popularity: 인기 순(주문 많은 순), order_count desc, product_id asc
+	 * TopRated: 평점 높은 순(review score), avg_score desc, product_id asc
+	 */
+	@Transactional(readOnly = true)
+	public ProductSearchResponse searchProduct(ProductSearchRequest request) {
+		List<Product> products = switch (request.sortType()) {
+			case Newest -> productRepository.findByNewest(toQueryKeyword(request.keyword()), request.lastCreatedAt(),
+				request.lastProductId(), request.pageSize());
+			case PriceAsc -> productRepository.findByPriceAsc(toQueryKeyword(request.keyword()), request.lastAmount(),
+				request.lastProductId(), request.pageSize());
+			case PriceDesc -> productRepository.findByPriceDesc(toQueryKeyword(request.keyword()), request.lastAmount(),
+				request.lastProductId(), request.pageSize());
+			case Popularity -> productRepository.findByPopularity(toQueryKeyword(
+				request.keyword()), request.lastOrderCount(), request.lastProductId(), request.pageSize());
+			case TopRated -> productRepository.findByTopRated(toQueryKeyword(request.keyword()), request.lastScore(),
+				request.lastProductId(), request.pageSize());
+		};
+		return ProductSearchResponse.of(products);
+	}
+
+	private String toQueryKeyword(String keyword) {
+		return "%" + keyword + "%";
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/domain/product/service/ProductReadService.java
+++ b/src/main/java/org/c4marathon/assignment/domain/product/service/ProductReadService.java
@@ -52,15 +52,15 @@ public class ProductReadService {
 	@Transactional(readOnly = true)
 	public ProductSearchResponse searchProduct(ProductSearchRequest request) {
 		List<Product> products = switch (request.sortType()) {
-			case Newest -> productRepository.findByNewest(toQueryKeyword(request.keyword()), request.lastCreatedAt(),
+			case NEWEST -> productRepository.findByNewest(toQueryKeyword(request.keyword()), request.lastCreatedAt(),
 				request.lastProductId(), request.pageSize());
-			case PriceAsc -> productRepository.findByPriceAsc(toQueryKeyword(request.keyword()), request.lastAmount(),
+			case PRICE_ASC -> productRepository.findByPriceAsc(toQueryKeyword(request.keyword()), request.lastAmount(),
 				request.lastProductId(), request.pageSize());
-			case PriceDesc -> productRepository.findByPriceDesc(toQueryKeyword(request.keyword()), request.lastAmount(),
-				request.lastProductId(), request.pageSize());
-			case Popularity -> productRepository.findByPopularity(toQueryKeyword(
+			case PRICE_DESC -> productRepository.findByPriceDesc(
+				toQueryKeyword(request.keyword()), request.lastAmount(), request.lastProductId(), request.pageSize());
+			case POPULARITY -> productRepository.findByPopularity(toQueryKeyword(
 				request.keyword()), request.lastOrderCount(), request.lastProductId(), request.pageSize());
-			case TopRated -> productRepository.findByTopRated(toQueryKeyword(request.keyword()), request.lastScore(),
+			case TOP_RATED -> productRepository.findByTopRated(toQueryKeyword(request.keyword()), request.lastScore(),
 				request.lastProductId(), request.pageSize());
 		};
 		return ProductSearchResponse.of(products);

--- a/src/main/java/org/c4marathon/assignment/domain/product/service/ProductReadService.java
+++ b/src/main/java/org/c4marathon/assignment/domain/product/service/ProductReadService.java
@@ -51,17 +51,16 @@ public class ProductReadService {
 	 */
 	@Transactional(readOnly = true)
 	public ProductSearchResponse searchProduct(ProductSearchRequest request) {
+		String keyword = toQueryKeyword(request.keyword());
+		Long productId = request.productId();
+		int pageSize = request.pageSize();
+
 		List<Product> products = switch (request.sortType()) {
-			case NEWEST -> productRepository.findByNewest(toQueryKeyword(request.keyword()), request.lastCreatedAt(),
-				request.lastProductId(), request.pageSize());
-			case PRICE_ASC -> productRepository.findByPriceAsc(toQueryKeyword(request.keyword()), request.lastAmount(),
-				request.lastProductId(), request.pageSize());
-			case PRICE_DESC -> productRepository.findByPriceDesc(
-				toQueryKeyword(request.keyword()), request.lastAmount(), request.lastProductId(), request.pageSize());
-			case POPULARITY -> productRepository.findByPopularity(toQueryKeyword(
-				request.keyword()), request.lastOrderCount(), request.lastProductId(), request.pageSize());
-			case TOP_RATED -> productRepository.findByTopRated(toQueryKeyword(request.keyword()), request.lastScore(),
-				request.lastProductId(), request.pageSize());
+			case NEWEST -> productRepository.findByNewest(keyword, request.createdAt(), productId, pageSize);
+			case PRICE_ASC -> productRepository.findByPriceAsc(keyword, request.amount(), productId, pageSize);
+			case PRICE_DESC -> productRepository.findByPriceDesc(keyword, request.amount(), productId, pageSize);
+			case POPULARITY -> productRepository.findByPopularity(keyword, request.orderCount(), productId, pageSize);
+			case TOP_RATED -> productRepository.findByTopRated(keyword, request.score(), productId, pageSize);
 		};
 		return ProductSearchResponse.of(products);
 	}

--- a/src/main/java/org/c4marathon/assignment/domain/review/controller/ReviewController.java
+++ b/src/main/java/org/c4marathon/assignment/domain/review/controller/ReviewController.java
@@ -1,0 +1,27 @@
+package org.c4marathon.assignment.domain.review.controller;
+
+import org.c4marathon.assignment.domain.consumer.entity.Consumer;
+import org.c4marathon.assignment.domain.review.dto.request.ReviewCreateRequest;
+import org.c4marathon.assignment.domain.review.service.ReviewService;
+import org.c4marathon.assignment.global.auth.ConsumerThreadLocal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/reviews")
+public class ReviewController {
+
+	private final ReviewService reviewService;
+
+	@PostMapping
+	public void createReview(@Valid @RequestBody ReviewCreateRequest request) {
+		Consumer consumer = ConsumerThreadLocal.get();
+		reviewService.createReview(consumer, request);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/org/c4marathon/assignment/domain/review/dto/request/ReviewCreateRequest.java
@@ -2,8 +2,6 @@ package org.c4marathon.assignment.domain.review.dto.request;
 
 import org.hibernate.validator.constraints.Range;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
 
 public record ReviewCreateRequest(

--- a/src/main/java/org/c4marathon/assignment/domain/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/org/c4marathon/assignment/domain/review/dto/request/ReviewCreateRequest.java
@@ -1,0 +1,15 @@
+package org.c4marathon.assignment.domain.review.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+
+public record ReviewCreateRequest(
+	@Min(value = 1, message = "score less than 1")
+	@Max(value = 5, message = "score more than 5")
+	int score,
+	@Size(max = 100, message = "comment length more than 100")
+	String comment,
+	long productId
+) {
+}

--- a/src/main/java/org/c4marathon/assignment/domain/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/org/c4marathon/assignment/domain/review/dto/request/ReviewCreateRequest.java
@@ -1,12 +1,13 @@
 package org.c4marathon.assignment.domain.review.dto.request;
 
+import org.hibernate.validator.constraints.Range;
+
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
 
 public record ReviewCreateRequest(
-	@Min(value = 1, message = "score less than 1")
-	@Max(value = 5, message = "score more than 5")
+	@Range(min = 1, max = 5, message = "invalid score range")
 	int score,
 	@Size(max = 100, message = "comment length more than 100")
 	String comment,

--- a/src/main/java/org/c4marathon/assignment/domain/review/entity/Review.java
+++ b/src/main/java/org/c4marathon/assignment/domain/review/entity/Review.java
@@ -1,0 +1,61 @@
+package org.c4marathon.assignment.domain.review.entity;
+
+import org.c4marathon.assignment.domain.base.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	name = "review_tbl",
+	indexes = {
+		@Index(name = "consumer_id_product_id_idx", columnList = "consumer_id, product_id")
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Review extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "review_id", columnDefinition = "BIGINT")
+	private Long id;
+
+	@NotNull
+	@Column(name = "consumer_id", columnDefinition = "BIGINT")
+	private Long consumerId;
+
+	@NotNull
+	@Column(name = "product_id", columnDefinition = "BIGINT")
+	private Long productId;
+
+	@NotNull
+	@Column(name = "score", columnDefinition = "TINYINT default 3")
+	private int score;
+
+	@Column(name = "comment", columnDefinition = "VARCHAR(100)")
+	private String comment;
+
+	@Builder
+	public Review(
+		Long consumerId,
+		Long productId,
+		int score,
+		String comment
+	) {
+		this.consumerId = consumerId;
+		this.productId = productId;
+		this.score = score;
+		this.comment = comment;
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/review/entity/Review.java
+++ b/src/main/java/org/c4marathon/assignment/domain/review/entity/Review.java
@@ -40,7 +40,7 @@ public class Review extends BaseEntity {
 	private Long productId;
 
 	@NotNull
-	@Column(name = "score", columnDefinition = "TINYINT default 3")
+	@Column(name = "score", columnDefinition = "INTEGER default 3")
 	private int score;
 
 	@Column(name = "comment", columnDefinition = "VARCHAR(100)")

--- a/src/main/java/org/c4marathon/assignment/domain/review/entity/ReviewFactory.java
+++ b/src/main/java/org/c4marathon/assignment/domain/review/entity/ReviewFactory.java
@@ -2,6 +2,10 @@ package org.c4marathon.assignment.domain.review.entity;
 
 import org.c4marathon.assignment.domain.review.dto.request.ReviewCreateRequest;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ReviewFactory {
 
 	public static Review buildReview(Long consumerId, ReviewCreateRequest request) {

--- a/src/main/java/org/c4marathon/assignment/domain/review/entity/ReviewFactory.java
+++ b/src/main/java/org/c4marathon/assignment/domain/review/entity/ReviewFactory.java
@@ -1,0 +1,17 @@
+package org.c4marathon.assignment.domain.review.entity;
+
+import org.c4marathon.assignment.domain.review.dto.request.ReviewCreateRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReviewFactory {
+
+	public Review buildReview(Long consumerId, ReviewCreateRequest request) {
+		return Review.builder()
+			.consumerId(consumerId)
+			.productId(request.productId())
+			.score(request.score())
+			.comment(request.comment())
+			.build();
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/review/entity/ReviewFactory.java
+++ b/src/main/java/org/c4marathon/assignment/domain/review/entity/ReviewFactory.java
@@ -1,12 +1,10 @@
 package org.c4marathon.assignment.domain.review.entity;
 
 import org.c4marathon.assignment.domain.review.dto.request.ReviewCreateRequest;
-import org.springframework.stereotype.Component;
 
-@Component
 public class ReviewFactory {
 
-	public Review buildReview(Long consumerId, ReviewCreateRequest request) {
+	public static Review buildReview(Long consumerId, ReviewCreateRequest request) {
 		return Review.builder()
 			.consumerId(consumerId)
 			.productId(request.productId())

--- a/src/main/java/org/c4marathon/assignment/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,9 @@
+package org.c4marathon.assignment.domain.review.repository;
+
+import org.c4marathon.assignment.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+	boolean existsByConsumerIdAndProductId(Long consumerId, Long productId);
+}

--- a/src/main/java/org/c4marathon/assignment/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/review/repository/ReviewRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
 	boolean existsByConsumerIdAndProductId(Long consumerId, Long productId);
+
+	Long countByProductId(Long productId);
 }

--- a/src/main/java/org/c4marathon/assignment/domain/review/service/ReviewService.java
+++ b/src/main/java/org/c4marathon/assignment/domain/review/service/ReviewService.java
@@ -2,12 +2,14 @@ package org.c4marathon.assignment.domain.review.service;
 
 import static org.c4marathon.assignment.domain.review.entity.ReviewFactory.*;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
 import org.c4marathon.assignment.domain.consumer.entity.Consumer;
 import org.c4marathon.assignment.domain.orderproduct.service.OrderProductReadService;
 import org.c4marathon.assignment.domain.product.entity.Product;
 import org.c4marathon.assignment.domain.product.service.ProductReadService;
 import org.c4marathon.assignment.domain.review.dto.request.ReviewCreateRequest;
-import org.c4marathon.assignment.domain.review.entity.ReviewFactory;
 import org.c4marathon.assignment.domain.review.repository.ReviewRepository;
 import org.c4marathon.assignment.global.error.ErrorCode;
 import org.springframework.stereotype.Service;
@@ -26,8 +28,10 @@ public class ReviewService {
 	/**
 	 * score, comment를 입력받아 Review entity 생성
 	 * product avgScore update
-	 * @throws org.c4marathon.assignment.global.error.BaseException 이미 해당 product에 대한 리뷰를 작성한 경우,
-	 * productId에 해당하는 구매 이력이 존재하지 않는 경우
+	 * @throws org.c4marathon.assignment.global.error.BaseException
+	 * productId에 해당하는 구매 이력이 존재하지 않는 경우, 또는 리뷰 작성 가능 기간(30일)이 지난 경우
+	 * -> 구매 이력은 구매 이후 30일이 지난 이후에 삭제되기 때문에 구매 이력이 없다면 아예 구매한 적이 없거나, 리뷰 작성 가능 기간이 지난 것을 의미함
+	 * 이미 해당 product에 대한 리뷰를 작성한 경우
 	 */
 	@Transactional
 	public void createReview(Consumer consumer, ReviewCreateRequest request) {
@@ -39,12 +43,14 @@ public class ReviewService {
 		}
 
 		Product product = productReadService.findById(request.productId());
-		Long reviewCount = productReadService.findReviewCount(request.productId());
+		Long reviewCount = reviewRepository.countByProductId(request.productId());
 		product.updateAvgScore(calculateAvgScore(product.getAvgScore(), reviewCount, request.score()));
 		reviewRepository.save(buildReview(consumer.getId(), request));
 	}
 
-	private Double calculateAvgScore(Double avgScore, Long reviewCount, int score) {
-		return ((avgScore * reviewCount) + score) / (reviewCount + 1);
+	private BigDecimal calculateAvgScore(BigDecimal avgScore, Long reviewCount, int score) {
+		return avgScore.multiply(BigDecimal.valueOf(reviewCount))
+			.add(BigDecimal.valueOf(score))
+			.divide(BigDecimal.valueOf(reviewCount + 1), 4, RoundingMode.DOWN);
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/domain/review/service/ReviewService.java
+++ b/src/main/java/org/c4marathon/assignment/domain/review/service/ReviewService.java
@@ -1,5 +1,7 @@
 package org.c4marathon.assignment.domain.review.service;
 
+import static org.c4marathon.assignment.domain.review.entity.ReviewFactory.*;
+
 import org.c4marathon.assignment.domain.consumer.entity.Consumer;
 import org.c4marathon.assignment.domain.orderproduct.service.OrderProductReadService;
 import org.c4marathon.assignment.domain.product.entity.Product;
@@ -18,7 +20,6 @@ import lombok.RequiredArgsConstructor;
 public class ReviewService {
 
 	private final ReviewRepository reviewRepository;
-	private final ReviewFactory reviewFactory;
 	private final ProductReadService productReadService;
 	private final OrderProductReadService orderProductReadService;
 
@@ -40,7 +41,7 @@ public class ReviewService {
 		Product product = productReadService.findById(request.productId());
 		Long reviewCount = productReadService.findReviewCount(request.productId());
 		product.updateAvgScore(calculateAvgScore(product.getAvgScore(), reviewCount, request.score()));
-		reviewRepository.save(reviewFactory.buildReview(consumer.getId(), request));
+		reviewRepository.save(buildReview(consumer.getId(), request));
 	}
 
 	private Double calculateAvgScore(Double avgScore, Long reviewCount, int score) {

--- a/src/main/java/org/c4marathon/assignment/domain/review/service/ReviewService.java
+++ b/src/main/java/org/c4marathon/assignment/domain/review/service/ReviewService.java
@@ -1,0 +1,43 @@
+package org.c4marathon.assignment.domain.review.service;
+
+import org.c4marathon.assignment.domain.consumer.entity.Consumer;
+import org.c4marathon.assignment.domain.product.entity.Product;
+import org.c4marathon.assignment.domain.product.service.ProductReadService;
+import org.c4marathon.assignment.domain.review.dto.request.ReviewCreateRequest;
+import org.c4marathon.assignment.domain.review.entity.ReviewFactory;
+import org.c4marathon.assignment.domain.review.repository.ReviewRepository;
+import org.c4marathon.assignment.global.error.ErrorCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+	private final ReviewRepository reviewRepository;
+	private final ReviewFactory reviewFactory;
+	private final ProductReadService productReadService;
+
+	/**
+	 * score, comment를 입력받아 Review entity 생성
+	 * product avgScore update
+	 * @throws org.c4marathon.assignment.global.error.BaseException 이미 해당 product에 대한 리뷰를 작성한 경우
+	 */
+	@Transactional
+	public void createReview(Consumer consumer, ReviewCreateRequest request) {
+		if (reviewRepository.existsByConsumerIdAndProductId(consumer.getId(), request.productId())) {
+			throw ErrorCode.REVIEW_ALREADY_EXISTS.baseException();
+		}
+
+		Product product = productReadService.findById(request.productId());
+		Long reviewCount = productReadService.findReviewCount(request.productId());
+		product.updateAvgScore(calculateAvgScore(product.getAvgScore(), reviewCount, request.score()));
+		reviewRepository.save(reviewFactory.buildReview(consumer.getId(), request));
+	}
+
+	private Double calculateAvgScore(Double avgScore, Long reviewCount, int score) {
+		return ((avgScore * reviewCount) + score) / (reviewCount + 1);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/review/service/ReviewService.java
+++ b/src/main/java/org/c4marathon/assignment/domain/review/service/ReviewService.java
@@ -25,7 +25,8 @@ public class ReviewService {
 	/**
 	 * score, comment를 입력받아 Review entity 생성
 	 * product avgScore update
-	 * @throws org.c4marathon.assignment.global.error.BaseException 이미 해당 product에 대한 리뷰를 작성한 경우
+	 * @throws org.c4marathon.assignment.global.error.BaseException 이미 해당 product에 대한 리뷰를 작성한 경우,
+	 * productId에 해당하는 구매 이력이 존재하지 않는 경우
 	 */
 	@Transactional
 	public void createReview(Consumer consumer, ReviewCreateRequest request) {

--- a/src/main/java/org/c4marathon/assignment/domain/review/service/ReviewService.java
+++ b/src/main/java/org/c4marathon/assignment/domain/review/service/ReviewService.java
@@ -1,6 +1,7 @@
 package org.c4marathon.assignment.domain.review.service;
 
 import org.c4marathon.assignment.domain.consumer.entity.Consumer;
+import org.c4marathon.assignment.domain.orderproduct.service.OrderProductReadService;
 import org.c4marathon.assignment.domain.product.entity.Product;
 import org.c4marathon.assignment.domain.product.service.ProductReadService;
 import org.c4marathon.assignment.domain.review.dto.request.ReviewCreateRequest;
@@ -19,6 +20,7 @@ public class ReviewService {
 	private final ReviewRepository reviewRepository;
 	private final ReviewFactory reviewFactory;
 	private final ProductReadService productReadService;
+	private final OrderProductReadService orderProductReadService;
 
 	/**
 	 * score, comment를 입력받아 Review entity 생성
@@ -27,6 +29,9 @@ public class ReviewService {
 	 */
 	@Transactional
 	public void createReview(Consumer consumer, ReviewCreateRequest request) {
+		if (!orderProductReadService.existsByConsumerIdAndProductId(consumer.getId(), request.productId())) {
+			throw ErrorCode.NOT_POSSIBLE_CREATE_REVIEW.baseException();
+		}
 		if (reviewRepository.existsByConsumerIdAndProductId(consumer.getId(), request.productId())) {
 			throw ErrorCode.REVIEW_ALREADY_EXISTS.baseException();
 		}

--- a/src/main/java/org/c4marathon/assignment/global/configuration/WebConfiguration.java
+++ b/src/main/java/org/c4marathon/assignment/global/configuration/WebConfiguration.java
@@ -21,7 +21,7 @@ public class WebConfiguration implements WebMvcConfigurer {
 	public void addInterceptors(InterceptorRegistry registry) {
 		registry
 			.addInterceptor(consumerInterceptor)
-			.addPathPatterns("/consumers/**");
+			.addPathPatterns("/consumers/**", "/reviews/**");
 
 		registry
 			.addInterceptor(sellerInterceptor)

--- a/src/main/java/org/c4marathon/assignment/global/constant/SortType.java
+++ b/src/main/java/org/c4marathon/assignment/global/constant/SortType.java
@@ -1,0 +1,10 @@
+package org.c4marathon.assignment.global.constant;
+
+public enum SortType {
+
+	Popularity,
+	TopRated,
+	PriceAsc,
+	PriceDesc,
+	Newest;
+}

--- a/src/main/java/org/c4marathon/assignment/global/constant/SortType.java
+++ b/src/main/java/org/c4marathon/assignment/global/constant/SortType.java
@@ -2,9 +2,9 @@ package org.c4marathon.assignment.global.constant;
 
 public enum SortType {
 
-	Popularity,
-	TopRated,
-	PriceAsc,
-	PriceDesc,
-	Newest;
+	POPULARITY,
+	TOP_RATED,
+	PRICE_ASC,
+	PRICE_DESC,
+	NEWEST;
 }

--- a/src/main/java/org/c4marathon/assignment/global/error/ErrorCode.java
+++ b/src/main/java/org/c4marathon/assignment/global/error/ErrorCode.java
@@ -31,7 +31,7 @@ public enum ErrorCode {
 	NOT_ENOUGH_POINT(BAD_REQUEST, "사용할 포인트가 부족합니다."),
 	CONSUMER_NOT_FOUND_BY_ID(NOT_FOUND, "id에 해당하는 Consumer가 존재하지 않습니다."),
 	REVIEW_ALREADY_EXISTS(CONFLICT, "해당 product에 대한 review가 이미 존재합니다."),
-	NOT_POSSIBLE_CREATE_REVIEW(NOT_FOUND, "해당 product에 대한 구매 이력이 존재하지 않습니다.");
+	NOT_POSSIBLE_CREATE_REVIEW(NOT_FOUND, "해당 product에 대한 구매 이력이 존재하지 않거나, 리뷰 작성 가능 기간이 지났습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/org/c4marathon/assignment/global/error/ErrorCode.java
+++ b/src/main/java/org/c4marathon/assignment/global/error/ErrorCode.java
@@ -31,7 +31,7 @@ public enum ErrorCode {
 	NOT_ENOUGH_POINT(BAD_REQUEST, "사용할 포인트가 부족합니다."),
 	CONSUMER_NOT_FOUND_BY_ID(NOT_FOUND, "id에 해당하는 Consumer가 존재하지 않습니다."),
 	REVIEW_ALREADY_EXISTS(CONFLICT, "해당 product에 대한 review가 이미 존재합니다."),
-	NOT_POSSIBLE_CREATE_REVIEW(BAD_REQUEST, "해당 product에 대한 구매 이력이 존재하지 않습니다.");
+	NOT_POSSIBLE_CREATE_REVIEW(NOT_FOUND, "해당 product에 대한 구매 이력이 존재하지 않습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/org/c4marathon/assignment/global/error/ErrorCode.java
+++ b/src/main/java/org/c4marathon/assignment/global/error/ErrorCode.java
@@ -30,7 +30,8 @@ public enum ErrorCode {
 	NOT_ENOUGH_PRODUCT_STOCK(BAD_REQUEST, "상품의 재고가 부족합니다."),
 	NOT_ENOUGH_POINT(BAD_REQUEST, "사용할 포인트가 부족합니다."),
 	CONSUMER_NOT_FOUND_BY_ID(NOT_FOUND, "id에 해당하는 Consumer가 존재하지 않습니다."),
-	REVIEW_ALREADY_EXISTS(CONFLICT, "해당 product에 대한 review가 이미 존재합니다.");
+	REVIEW_ALREADY_EXISTS(CONFLICT, "해당 product에 대한 review가 이미 존재합니다."),
+	NOT_POSSIBLE_CREATE_REVIEW(BAD_REQUEST, "해당 product에 대한 구매 이력이 존재하지 않습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/org/c4marathon/assignment/global/error/ErrorCode.java
+++ b/src/main/java/org/c4marathon/assignment/global/error/ErrorCode.java
@@ -29,7 +29,8 @@ public enum ErrorCode {
 	CONFIRM_NOT_AVAILABLE(BAD_REQUEST, "구매 확정이 불가능한 상태입니다."),
 	NOT_ENOUGH_PRODUCT_STOCK(BAD_REQUEST, "상품의 재고가 부족합니다."),
 	NOT_ENOUGH_POINT(BAD_REQUEST, "사용할 포인트가 부족합니다."),
-	CONSUMER_NOT_FOUND_BY_ID(NOT_FOUND, "id에 해당하는 Consumer가 존재하지 않습니다.");
+	CONSUMER_NOT_FOUND_BY_ID(NOT_FOUND, "id에 해당하는 Consumer가 존재하지 않습니다."),
+	REVIEW_ALREADY_EXISTS(CONFLICT, "해당 product에 대한 review가 이미 존재합니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/org/c4marathon/assignment/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/c4marathon/assignment/global/error/GlobalExceptionHandler.java
@@ -37,7 +37,7 @@ public class GlobalExceptionHandler {
 	}
 
 	@ExceptionHandler(value = ConstraintViolationException.class)
-	public ResponseEntity<ExceptionResponse> constraintViolationException(ConstraintViolationException e) {
+	public ResponseEntity<ExceptionResponse> constraintViolationException() {
 		return new ResponseEntity<>(
 			new ExceptionResponse(BIND_ERROR.name(), BIND_ERROR.getMessage()),
 			HttpStatus.BAD_REQUEST

--- a/src/main/java/org/c4marathon/assignment/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/c4marathon/assignment/global/error/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 
 @RestControllerAdvice
@@ -31,6 +32,14 @@ public class GlobalExceptionHandler {
 			fieldError.getField(), fieldError.getRejectedValue(), fieldError.getDefaultMessage());
 		return new ResponseEntity<>(
 			new BindExceptionResponse(BIND_ERROR.name(), BIND_ERROR.getMessage(), fieldError.getField()),
+			HttpStatus.BAD_REQUEST
+		);
+	}
+
+	@ExceptionHandler(value = ConstraintViolationException.class)
+	public ResponseEntity<ExceptionResponse> constraintViolationException(ConstraintViolationException e) {
+		return new ResponseEntity<>(
+			new ExceptionResponse(BIND_ERROR.name(), BIND_ERROR.getMessage()),
 			HttpStatus.BAD_REQUEST
 		);
 	}

--- a/src/main/java/org/c4marathon/assignment/global/scheduler/OrderProductScheduler.java
+++ b/src/main/java/org/c4marathon/assignment/global/scheduler/OrderProductScheduler.java
@@ -1,0 +1,33 @@
+package org.c4marathon.assignment.global.scheduler;
+
+import java.time.LocalDateTime;
+
+import org.c4marathon.assignment.domain.orderproduct.repository.OrderProductRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OrderProductScheduler {
+
+	private static final int PAGINATION_SIZE = 1000;
+	private static final int EXISTS_DAY = 30;
+
+	private final OrderProductRepository orderProductRepository;
+
+	/**
+	 * 24시간 마다 수행되는 스케줄러로, 30일 이전의 주문 내역을 삭제
+	 */
+	@Scheduled(cron = "0 0 0 * * ?")
+	@Transactional
+	public void scheduleDeleteOrderProducts() {
+		int deletedCount;
+		do {
+			LocalDateTime dateTime = LocalDateTime.now().minusDays(EXISTS_DAY);
+			deletedCount = orderProductRepository.deleteOrderProductTable(dateTime, PAGINATION_SIZE);
+		} while (deletedCount != 0);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
         format_sql: true
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     database: mysql
 
   datasource:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
         format_sql: true
     show-sql: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     database: mysql
 
   datasource:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,9 @@ spring:
       maximum-pool-size: 10
     url: jdbc:mysql://localhost:3306/community?rewriteBatchedStatements=true
 
+mybatis:
+  mapper-locations: classpath:mapper/*.xml
+
 logging:
   level:
     org.c4marathon.assignment.global.error: debug

--- a/src/main/resources/mapper/ProductMapper.xml
+++ b/src/main/resources/mapper/ProductMapper.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTO Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.c4marathon.assignment.domain.product.repository.ProductMapper">
+    <select id="selectByCondition"
+            parameterType="org.c4marathon.assignment.domain.product.dto.request.ProductSearchRequest"
+            resultType="org.c4marathon.assignment.domain.product.dto.response.ProductSearchEntry">
+        select
+        p.product_id as id,
+        p.name as name,
+        p.description as description,
+        p.amount as amount,
+        p.stock as stock,
+        p.created_at as createdAt,
+        p.order_count as orderCount,
+        p.avg_score as avgScore
+        from product_tbl p
+        where name like CONCAT('%', #{keyword}, '%')
+        <choose>
+            <when test="sortType.name() == 'NEWEST'">
+                and (p.created_at &lt; #{createdAt} or (p.created_at = #{createdAt} and p.product_id &gt; #{productId}))
+                order by p.created_at desc, p.product_id
+            </when>
+            <when test="sortType.name() == 'PRICE_ASC'">
+                and (p.amount &gt; #{amount} or (p.amount = #{amount} and p.product_id &gt; #{productId}))
+                order by p.amount, p.product_id
+            </when>
+            <when test="sortType.name() == 'PRICE_DESC'">
+                and (p.amount &lt; #{amount} or (p.amount = #{amount} and p.product_id &gt; #{productId}))
+                order by p.amount desc, p.product_id
+            </when>
+            <when test="sortType.name() == 'POPULARITY'">
+                and (p.order_count &lt; #{orderCount}
+                    or (p.order_count = #{orderCount} and p.product_id &gt; #{productId}))
+                order by p.order_count desc, p.product_id
+            </when>
+            <when test="sortType.name() == 'TOP_RATED'">
+                and (p.avg_score &lt; #{score} or (p.avg_score = #{score} and p.product_id &gt; #{productId}))
+                order by p.avg_score desc, p.product_id
+            </when>
+        </choose>
+        limit #{pageSize}
+    </select>
+</mapper>

--- a/src/main/resources/mapper/ProductMapper.xml
+++ b/src/main/resources/mapper/ProductMapper.xml
@@ -32,7 +32,7 @@
             </when>
             <when test="sortType.name() == 'POPULARITY'">
                 and (p.order_count &lt; #{orderCount}
-                    or (p.order_count = #{orderCount} and p.product_id &gt; #{productId}))
+                or (p.order_count = #{orderCount} and p.product_id &gt; #{productId}))
                 order by p.order_count desc, p.product_id
             </when>
             <when test="sortType.name() == 'TOP_RATED'">

--- a/src/test/java/org/c4marathon/assignment/domain/controller/ControllerTestSupport.java
+++ b/src/test/java/org/c4marathon/assignment/domain/controller/ControllerTestSupport.java
@@ -11,6 +11,10 @@ import org.c4marathon.assignment.domain.deliverycompany.controller.DeliveryCompa
 import org.c4marathon.assignment.domain.deliverycompany.service.DeliveryCompanyService;
 import org.c4marathon.assignment.domain.pay.controller.PayController;
 import org.c4marathon.assignment.domain.pay.service.PayService;
+import org.c4marathon.assignment.domain.product.controller.ProductController;
+import org.c4marathon.assignment.domain.product.service.ProductReadService;
+import org.c4marathon.assignment.domain.review.controller.ReviewController;
+import org.c4marathon.assignment.domain.review.service.ReviewService;
 import org.c4marathon.assignment.domain.seller.controller.SellerController;
 import org.c4marathon.assignment.domain.seller.service.SellerService;
 import org.c4marathon.assignment.global.interceptor.ConsumerInterceptor;
@@ -30,7 +34,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 @WebMvcTest(controllers = {AuthController.class, ConsumerController.class, DeliveryCompanyController.class,
-	PayController.class, SellerController.class})
+	PayController.class, SellerController.class, ProductController.class, ReviewController.class})
 @MockBean(JpaMetamodelMappingContext.class)
 public abstract class ControllerTestSupport {
 
@@ -65,4 +69,8 @@ public abstract class ControllerTestSupport {
 	protected PayService payService;
 	@MockBean
 	protected AuthService authService;
+	@MockBean
+	protected ProductReadService productReadService;
+	@MockBean
+	protected ReviewService reviewService;
 }

--- a/src/test/java/org/c4marathon/assignment/domain/controller/product/ProductControllerTest.java
+++ b/src/test/java/org/c4marathon/assignment/domain/controller/product/ProductControllerTest.java
@@ -1,0 +1,83 @@
+package org.c4marathon.assignment.domain.controller.product;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.c4marathon.assignment.domain.controller.ControllerTestSupport;
+import org.c4marathon.assignment.domain.product.dto.request.ProductSearchRequest;
+import org.c4marathon.assignment.domain.product.dto.response.ProductSearchEntry;
+import org.c4marathon.assignment.domain.product.dto.response.ProductSearchResponse;
+import org.c4marathon.assignment.global.constant.SortType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class ProductControllerTest extends ControllerTestSupport {
+
+	@DisplayName("상품 검색 시")
+	@Nested
+	class SearchProduct {
+
+		private static final String REQUEST_URL = "/products";
+
+		@BeforeEach
+		void setUp() {
+			given(productReadService.searchProduct(any(ProductSearchRequest.class)))
+				.willReturn(new ProductSearchResponse(List.of(new ProductSearchEntry(1, "name", "des", 1, 1,
+					LocalDateTime.now(), 0L, 0.0))));
+		}
+
+		@DisplayName("올바른 파라미터를 요청하면 성공한다.")
+		@Test
+		void success_when_validRequest() throws Exception {
+			mockMvc.perform(get(REQUEST_URL)
+					.param("keyword", "ab")
+					.param("sortType", SortType.Newest.name())
+					.param("pageSize", "1"))
+				.andExpectAll(
+					status().isOk(),
+					jsonPath("$.productSearchEntries[0].id").value(1),
+					jsonPath("$.productSearchEntries[0].name").value("name"),
+					jsonPath("$.productSearchEntries[0].description").value("des"),
+					jsonPath("$.productSearchEntries[0].amount").value(1),
+					jsonPath("$.productSearchEntries[0].stock").value(1)
+				);
+		}
+
+		@DisplayName("keyword가 null이거나 길이가 2보다 작으면 실패한다.")
+		@ParameterizedTest
+		@ValueSource(strings = {"a", "b"})
+		@NullAndEmptySource
+		void fail_when_keywordIsNullOrLessThanTwo(String keyword) throws Exception {
+			mockMvc.perform(get(REQUEST_URL)
+					.param("keyword", keyword)
+					.param("sortType", SortType.Newest.name())
+					.param("pageSize", "1"))
+				.andExpectAll(
+					status().isBadRequest()
+				);
+		}
+
+		@DisplayName("sortType이 null이거나 존재하지 않은 값이면 실패한다.")
+		@ParameterizedTest
+		@ValueSource(strings = {"a", "b"})
+		@NullAndEmptySource
+		void fail_when_sortTypeIsNullOrInvalid(String sortType) throws Exception {
+			mockMvc.perform(get(REQUEST_URL)
+					.param("keyword", "ab")
+					.param("sortType", sortType)
+					.param("pageSize", "1"))
+				.andExpectAll(
+					status().isBadRequest()
+				);
+		}
+	}
+}

--- a/src/test/java/org/c4marathon/assignment/domain/controller/product/ProductControllerTest.java
+++ b/src/test/java/org/c4marathon/assignment/domain/controller/product/ProductControllerTest.java
@@ -40,7 +40,7 @@ public class ProductControllerTest extends ControllerTestSupport {
 		void success_when_validRequest() throws Exception {
 			mockMvc.perform(get(REQUEST_URL)
 					.param("keyword", "ab")
-					.param("sortType", SortType.Newest.name())
+					.param("sortType", SortType.NEWEST.name())
 					.param("pageSize", "1"))
 				.andExpectAll(
 					status().isOk(),
@@ -59,7 +59,7 @@ public class ProductControllerTest extends ControllerTestSupport {
 		void fail_when_keywordIsNullOrLessThanTwo(String keyword) throws Exception {
 			mockMvc.perform(get(REQUEST_URL)
 					.param("keyword", keyword)
-					.param("sortType", SortType.Newest.name())
+					.param("sortType", SortType.NEWEST.name())
 					.param("pageSize", "1"))
 				.andExpectAll(
 					status().isBadRequest()

--- a/src/test/java/org/c4marathon/assignment/domain/controller/review/ReviewControllerTest.java
+++ b/src/test/java/org/c4marathon/assignment/domain/controller/review/ReviewControllerTest.java
@@ -1,0 +1,68 @@
+package org.c4marathon.assignment.domain.controller.review;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.nio.charset.StandardCharsets;
+
+import org.c4marathon.assignment.domain.controller.ControllerTestSupport;
+import org.c4marathon.assignment.domain.review.dto.request.ReviewCreateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.MediaType;
+
+public class ReviewControllerTest extends ControllerTestSupport {
+
+	@DisplayName("리뷰 작성 시")
+	@Nested
+	class CreateReview {
+
+		private static final String REQUEST_URL = "/reviews";
+
+		@DisplayName("올바른 요청을 하면 성공한다.")
+		@Test
+		void success_when_validRequest() throws Exception {
+			ReviewCreateRequest request = new ReviewCreateRequest(1, "comment", 100);
+
+			mockMvc.perform(post(REQUEST_URL)
+					.content(om.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+					.characterEncoding(StandardCharsets.UTF_8))
+				.andExpectAll(
+					status().isOk()
+				);
+		}
+
+		@DisplayName("score가 올바른 범위가 아니면 실패한다.")
+		@ParameterizedTest
+		@ValueSource(ints = {0, -1, 6, 7})
+		void fail_when_invalidScoreRange(int score) throws Exception {
+			ReviewCreateRequest request = new ReviewCreateRequest(score, "comment", 100);
+
+			mockMvc.perform(post(REQUEST_URL)
+					.content(om.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+					.characterEncoding(StandardCharsets.UTF_8))
+				.andExpectAll(
+					status().isBadRequest()
+				);
+		}
+
+		@DisplayName("comment의 크기가 100이 넘어가면 실패한다.")
+		@Test
+		void fail_when_commentLengthGreaterThan100() throws Exception {
+			ReviewCreateRequest request = new ReviewCreateRequest(1, "a".repeat(101), 100);
+
+			mockMvc.perform(post(REQUEST_URL)
+					.content(om.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+					.characterEncoding(StandardCharsets.UTF_8))
+				.andExpectAll(
+					status().isBadRequest()
+				);
+		}
+	}
+}

--- a/src/test/java/org/c4marathon/assignment/domain/entity/ConsumerTest.java
+++ b/src/test/java/org/c4marathon/assignment/domain/entity/ConsumerTest.java
@@ -1,0 +1,35 @@
+package org.c4marathon.assignment.domain.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.c4marathon.assignment.domain.consumer.entity.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class ConsumerTest {
+
+	@DisplayName("Consumer Entity test")
+	@Nested
+	class ConsumerEntityTest {
+
+		private Consumer consumer;
+
+		@BeforeEach
+		void setUp() {
+			consumer = new Consumer("email", "address");
+		}
+
+		@DisplayName("consumer entity의 메서드 수행 시, 필드가 변경된다.")
+		@Test
+		void updateField_when_invokeEntityMethod() {
+			consumer.addBalance(100L);
+			assertThat(consumer.getBalance()).isEqualTo(100L);
+			consumer.decreaseBalance(100L);
+			assertThat(consumer.getBalance()).isZero();
+			consumer.updatePoint(100L);
+			assertThat(consumer.getPoint()).isEqualTo(100L);
+		}
+	}
+}

--- a/src/test/java/org/c4marathon/assignment/domain/entity/OrderTest.java
+++ b/src/test/java/org/c4marathon/assignment/domain/entity/OrderTest.java
@@ -1,0 +1,44 @@
+package org.c4marathon.assignment.domain.entity;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.c4marathon.assignment.global.constant.OrderStatus.*;
+
+import org.c4marathon.assignment.domain.order.entity.Order;
+import org.c4marathon.assignment.global.constant.OrderStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class OrderTest {
+
+	@DisplayName("Order Entity test")
+	@Nested
+	class OrderEntityTest {
+
+		private Order order;
+
+		@BeforeEach
+		void setUp() {
+			order = Order.builder()
+				.orderStatus(OrderStatus.COMPLETE_PAYMENT)
+				.consumer(null)
+				.usedPoint(0)
+				.build();
+		}
+
+		@DisplayName("order entity의 메서드 수행 시, 필드가 변경된다.")
+		@Test
+		void updateField_when_invokeOrderEntityMethod() {
+			order.updateOrderStatus(CONFIRM);
+			order.updateDeliveryId(1L);
+			order.updateEarnedPoint(10);
+			order.updateTotalAmount(1000);
+
+			assertThat(order.getOrderStatus()).isEqualTo(CONFIRM);
+			assertThat(order.getDeliveryId()).isEqualTo(1L);
+			assertThat(order.getEarnedPoint()).isEqualTo(10);
+			assertThat(order.getTotalAmount()).isEqualTo(1000);
+		}
+	}
+}

--- a/src/test/java/org/c4marathon/assignment/domain/entity/ProductTest.java
+++ b/src/test/java/org/c4marathon/assignment/domain/entity/ProductTest.java
@@ -1,0 +1,51 @@
+package org.c4marathon.assignment.domain.entity;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.c4marathon.assignment.global.constant.ProductStatus.*;
+
+import org.c4marathon.assignment.domain.product.entity.Product;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class ProductTest {
+
+	@DisplayName("Product Entity test")
+	@Nested
+	class ProductEntityTest {
+
+		private Product product;
+
+		@BeforeEach
+		void setUp() {
+			product = Product.builder()
+				.name("name")
+				.description("des")
+				.amount(100L)
+				.stock(100)
+				.seller(null)
+				.build();
+		}
+
+		@DisplayName("consumer entity의 메서드 수행 시, 필드가 변경된다.")
+		@Test
+		void updateField_when_invokeEntityMethod() {
+			assertThat(product.getName()).isEqualTo("name");
+			assertThat(product.getDescription()).isEqualTo("des");
+			assertThat(product.getAmount()).isEqualTo(100L);
+			assertThat(product.getStock()).isEqualTo(100);
+			assertThat(product.getProductStatus()).isEqualTo(IN_STOCK);
+			assertThat(product.getOrderCount()).isZero();
+			assertThat(product.getAvgScore()).isZero();
+
+			product.decreaseStock(100);
+			assertThat(product.getProductStatus()).isEqualTo(OUT_OF_STOCK);
+			assertThat(product.isSoldOut()).isTrue();
+			product.increaseOrderCount();
+			assertThat(product.getOrderCount()).isEqualTo(1);
+			product.updateAvgScore(1.0);
+			assertThat(product.getAvgScore()).isEqualTo(1.0);
+		}
+	}
+}

--- a/src/test/java/org/c4marathon/assignment/domain/entity/ProductTest.java
+++ b/src/test/java/org/c4marathon/assignment/domain/entity/ProductTest.java
@@ -3,6 +3,8 @@ package org.c4marathon.assignment.domain.entity;
 import static org.assertj.core.api.Assertions.*;
 import static org.c4marathon.assignment.global.constant.ProductStatus.*;
 
+import java.math.BigDecimal;
+
 import org.c4marathon.assignment.domain.product.entity.Product;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -44,8 +46,8 @@ public class ProductTest {
 			assertThat(product.isSoldOut()).isTrue();
 			product.increaseOrderCount();
 			assertThat(product.getOrderCount()).isEqualTo(1);
-			product.updateAvgScore(1.0);
-			assertThat(product.getAvgScore()).isEqualTo(1.0);
+			product.updateAvgScore(BigDecimal.ONE);
+			assertThat(product.getAvgScore()).isEqualTo(BigDecimal.ONE);
 		}
 	}
 }

--- a/src/test/java/org/c4marathon/assignment/domain/service/ServiceTestSupport.java
+++ b/src/test/java/org/c4marathon/assignment/domain/service/ServiceTestSupport.java
@@ -15,6 +15,7 @@ import org.c4marathon.assignment.domain.pay.repository.PayRepository;
 import org.c4marathon.assignment.domain.pointlog.repository.PointLogRepository;
 import org.c4marathon.assignment.domain.product.entity.Product;
 import org.c4marathon.assignment.domain.product.repository.ProductRepository;
+import org.c4marathon.assignment.domain.review.entity.ReviewFactory;
 import org.c4marathon.assignment.domain.review.repository.ReviewRepository;
 import org.c4marathon.assignment.domain.seller.entity.Seller;
 import org.c4marathon.assignment.domain.seller.repository.SellerRepository;
@@ -45,6 +46,8 @@ public abstract class ServiceTestSupport {
 	protected PointLogRepository pointLogRepository;
 	@Mock
 	protected ReviewRepository reviewRepository;
+	@Mock
+	protected ReviewFactory reviewFactory;
 
 	@Mock
 	protected Order order;

--- a/src/test/java/org/c4marathon/assignment/domain/service/ServiceTestSupport.java
+++ b/src/test/java/org/c4marathon/assignment/domain/service/ServiceTestSupport.java
@@ -15,6 +15,7 @@ import org.c4marathon.assignment.domain.pay.repository.PayRepository;
 import org.c4marathon.assignment.domain.pointlog.repository.PointLogRepository;
 import org.c4marathon.assignment.domain.product.entity.Product;
 import org.c4marathon.assignment.domain.product.repository.ProductRepository;
+import org.c4marathon.assignment.domain.review.repository.ReviewRepository;
 import org.c4marathon.assignment.domain.seller.entity.Seller;
 import org.c4marathon.assignment.domain.seller.repository.SellerRepository;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,6 +43,8 @@ public abstract class ServiceTestSupport {
 	protected PayRepository payRepository;
 	@Mock
 	protected PointLogRepository pointLogRepository;
+	@Mock
+	protected ReviewRepository reviewRepository;
 
 	@Mock
 	protected Order order;

--- a/src/test/java/org/c4marathon/assignment/domain/service/ServiceTestSupport.java
+++ b/src/test/java/org/c4marathon/assignment/domain/service/ServiceTestSupport.java
@@ -14,8 +14,8 @@ import org.c4marathon.assignment.domain.orderproduct.repository.OrderProductRepo
 import org.c4marathon.assignment.domain.pay.repository.PayRepository;
 import org.c4marathon.assignment.domain.pointlog.repository.PointLogRepository;
 import org.c4marathon.assignment.domain.product.entity.Product;
+import org.c4marathon.assignment.domain.product.repository.ProductMapper;
 import org.c4marathon.assignment.domain.product.repository.ProductRepository;
-import org.c4marathon.assignment.domain.review.entity.ReviewFactory;
 import org.c4marathon.assignment.domain.review.repository.ReviewRepository;
 import org.c4marathon.assignment.domain.seller.entity.Seller;
 import org.c4marathon.assignment.domain.seller.repository.SellerRepository;
@@ -47,7 +47,7 @@ public abstract class ServiceTestSupport {
 	@Mock
 	protected ReviewRepository reviewRepository;
 	@Mock
-	protected ReviewFactory reviewFactory;
+	protected ProductMapper productMapper;
 
 	@Mock
 	protected Order order;

--- a/src/test/java/org/c4marathon/assignment/domain/service/product/ProductReadServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/domain/service/product/ProductReadServiceTest.java
@@ -1,20 +1,30 @@
 package org.c4marathon.assignment.domain.service.product;
 
+import static java.util.Comparator.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.c4marathon.assignment.global.error.ErrorCode.*;
 import static org.mockito.BDDMockito.*;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
+import org.c4marathon.assignment.domain.product.entity.Product;
+import org.c4marathon.assignment.domain.product.repository.ProductRepository;
 import org.c4marathon.assignment.domain.product.service.ProductReadService;
 import org.c4marathon.assignment.domain.seller.entity.Seller;
 import org.c4marathon.assignment.domain.service.ServiceTestSupport;
+import org.c4marathon.assignment.global.constant.SortType;
 import org.c4marathon.assignment.global.error.BaseException;
 import org.c4marathon.assignment.global.error.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
 public class ProductReadServiceTest extends ServiceTestSupport {
 
@@ -63,6 +73,49 @@ public class ProductReadServiceTest extends ServiceTestSupport {
 			assertThatThrownBy(() -> productReadService.findById(product.getId() + 1))
 				.isInstanceOf(exception.getClass())
 				.hasMessage(exception.getMessage());
+		}
+	}
+
+	@DisplayName("reviewCount 조회 시")
+	@Nested
+	class FindReviewCount {
+
+		@DisplayName("product_id에 해당하는 reviewCount를 조회한다.")
+		@Test
+		void returnReviewCount_when_exists() {
+			given(productRepository.findReviewCount(anyLong())).willReturn(10L);
+			final long reviewCount = productReadService.findReviewCount(product.getId());
+			assertThat(reviewCount).isEqualTo(10L);
+		}
+	}
+
+	@DisplayName("상품 검색 시")
+	@Nested
+	@SpringBootTest
+	class SearchProduct {
+
+		@Autowired
+		private ProductRepository productRepository;
+
+		@DisplayName("")
+		@ParameterizedTest
+		@EnumSource(value = SortType.class)
+		void test(SortType sortType) {
+			List<Product> result = switch (sortType) {
+				case TopRated -> productRepository.findByTopRated("%ab%", 0.0, 0L, 100);
+				case Newest -> productRepository.findByNewest("%ab%", LocalDateTime.now(), 0L, 100);
+				case PriceAsc -> productRepository.findByPriceAsc("%ab%", 0L, 0L, 100);
+				case PriceDesc -> productRepository.findByPriceDesc("%ab%", 0L, 0L, 100);
+				case Popularity -> productRepository.findByPopularity("%ab%", 0L, 0L, 100);
+			};
+
+			switch (sortType) {
+				case TopRated -> assertThat(result).isSortedAccordingTo(comparing(Product::getAvgScore).reversed());
+				case Newest -> assertThat(result).isSortedAccordingTo(comparing(Product::getCreatedAt).reversed());
+				case PriceAsc -> assertThat(result).isSortedAccordingTo(comparing(Product::getAmount));
+				case PriceDesc -> assertThat(result).isSortedAccordingTo(comparing(Product::getAmount).reversed());
+				case Popularity -> assertThat(result).isSortedAccordingTo(comparing(Product::getOrderCount).reversed());
+			}
 		}
 	}
 }

--- a/src/test/java/org/c4marathon/assignment/domain/service/product/ProductReadServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/domain/service/product/ProductReadServiceTest.java
@@ -74,19 +74,6 @@ public class ProductReadServiceTest extends ServiceTestSupport {
 		}
 	}
 
-	@DisplayName("reviewCount 조회 시")
-	@Nested
-	class FindReviewCount {
-
-		@DisplayName("product_id에 해당하는 reviewCount를 조회한다.")
-		@Test
-		void returnReviewCount_when_exists() {
-			given(productRepository.findReviewCount(anyLong())).willReturn(10L);
-			final long reviewCount = productReadService.findReviewCount(product.getId());
-			assertThat(reviewCount).isEqualTo(10L);
-		}
-	}
-
 	@DisplayName("상품 검색 시")
 	@Nested
 	class SearchProduct {

--- a/src/test/java/org/c4marathon/assignment/domain/service/product/ProductReadServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/domain/service/product/ProductReadServiceTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
-import org.springframework.boot.test.context.SpringBootTest;
 
 public class ProductReadServiceTest extends ServiceTestSupport {
 

--- a/src/test/java/org/c4marathon/assignment/domain/service/product/ProductReadServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/domain/service/product/ProductReadServiceTest.java
@@ -97,24 +97,24 @@ public class ProductReadServiceTest extends ServiceTestSupport {
 		@Autowired
 		private ProductRepository productRepository;
 
-		@DisplayName("")
+		@DisplayName("정렬된 순서로 조회된다.")
 		@ParameterizedTest
 		@EnumSource(value = SortType.class)
-		void test(SortType sortType) {
+		void returnSortedList_when_searchProduct(SortType sortType) {
 			List<Product> result = switch (sortType) {
-				case TopRated -> productRepository.findByTopRated("%ab%", 0.0, 0L, 100);
-				case Newest -> productRepository.findByNewest("%ab%", LocalDateTime.now(), 0L, 100);
-				case PriceAsc -> productRepository.findByPriceAsc("%ab%", 0L, 0L, 100);
-				case PriceDesc -> productRepository.findByPriceDesc("%ab%", 0L, 0L, 100);
-				case Popularity -> productRepository.findByPopularity("%ab%", 0L, 0L, 100);
+				case TOP_RATED -> productRepository.findByTopRated("%ab%", 0.0, 0L, 100);
+				case NEWEST -> productRepository.findByNewest("%ab%", LocalDateTime.now(), 0L, 100);
+				case PRICE_ASC -> productRepository.findByPriceAsc("%ab%", 0L, 0L, 100);
+				case PRICE_DESC -> productRepository.findByPriceDesc("%ab%", 0L, 0L, 100);
+				case POPULARITY -> productRepository.findByPopularity("%ab%", 0L, 0L, 100);
 			};
 
 			switch (sortType) {
-				case TopRated -> assertThat(result).isSortedAccordingTo(comparing(Product::getAvgScore).reversed());
-				case Newest -> assertThat(result).isSortedAccordingTo(comparing(Product::getCreatedAt).reversed());
-				case PriceAsc -> assertThat(result).isSortedAccordingTo(comparing(Product::getAmount));
-				case PriceDesc -> assertThat(result).isSortedAccordingTo(comparing(Product::getAmount).reversed());
-				case Popularity -> assertThat(result).isSortedAccordingTo(comparing(Product::getOrderCount).reversed());
+				case TOP_RATED -> assertThat(result).isSortedAccordingTo(comparing(Product::getAvgScore).reversed());
+				case NEWEST -> assertThat(result).isSortedAccordingTo(comparing(Product::getCreatedAt).reversed());
+				case PRICE_ASC -> assertThat(result).isSortedAccordingTo(comparing(Product::getAmount));
+				case PRICE_DESC -> assertThat(result).isSortedAccordingTo(comparing(Product::getAmount).reversed());
+				case POPULARITY -> assertThat(result).isSortedAccordingTo(comparing(Product::getOrderCount).reversed());
 			}
 		}
 	}

--- a/src/test/java/org/c4marathon/assignment/domain/service/product/ProductReadServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/domain/service/product/ProductReadServiceTest.java
@@ -90,7 +90,6 @@ public class ProductReadServiceTest extends ServiceTestSupport {
 
 	@DisplayName("상품 검색 시")
 	@Nested
-	@SpringBootTest
 	class SearchProduct {
 
 		@DisplayName("정렬된 순서로 조회된다.")

--- a/src/test/java/org/c4marathon/assignment/domain/service/review/ReviewFactoryTest.java
+++ b/src/test/java/org/c4marathon/assignment/domain/service/review/ReviewFactoryTest.java
@@ -1,6 +1,7 @@
 package org.c4marathon.assignment.domain.service.review;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.c4marathon.assignment.domain.review.entity.ReviewFactory.*;
 
 import org.c4marathon.assignment.domain.review.dto.request.ReviewCreateRequest;
 import org.c4marathon.assignment.domain.review.entity.Review;
@@ -23,7 +24,7 @@ public class ReviewFactoryTest extends ServiceTestSupport {
 		@Test
 		@DisplayName("review entity 생성 시 request에 맞는 필드가 주입된다.")
 		void createReviewEntity() {
-			Review review = reviewFactory.buildReview(1L, new ReviewCreateRequest(3, "comment", 1));
+			Review review = buildReview(1L, new ReviewCreateRequest(3, "comment", 1));
 			assertThat(review.getProductId()).isEqualTo(1L);
 			assertThat(review.getComment()).isEqualTo("comment");
 			assertThat(review.getScore()).isEqualTo(3);

--- a/src/test/java/org/c4marathon/assignment/domain/service/review/ReviewFactoryTest.java
+++ b/src/test/java/org/c4marathon/assignment/domain/service/review/ReviewFactoryTest.java
@@ -1,0 +1,32 @@
+package org.c4marathon.assignment.domain.service.review;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.c4marathon.assignment.domain.review.dto.request.ReviewCreateRequest;
+import org.c4marathon.assignment.domain.review.entity.Review;
+import org.c4marathon.assignment.domain.review.entity.ReviewFactory;
+import org.c4marathon.assignment.domain.service.ServiceTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+
+public class ReviewFactoryTest extends ServiceTestSupport {
+
+	@InjectMocks
+	private ReviewFactory reviewFactory;
+
+	@DisplayName("review entity 생성 시")
+	@Nested
+	class BuildReview {
+
+		@Test
+		@DisplayName("review entity 생성 시 request에 맞는 필드가 주입된다.")
+		void createReviewEntity() {
+			Review review = reviewFactory.buildReview(1L, new ReviewCreateRequest(3, "comment", 1));
+			assertThat(review.getProductId()).isEqualTo(1L);
+			assertThat(review.getComment()).isEqualTo("comment");
+			assertThat(review.getScore()).isEqualTo(3);
+		}
+	}
+}

--- a/src/test/java/org/c4marathon/assignment/domain/service/review/ReviewServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/domain/service/review/ReviewServiceTest.java
@@ -1,0 +1,67 @@
+package org.c4marathon.assignment.domain.service.review;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.c4marathon.assignment.domain.product.service.ProductReadService;
+import org.c4marathon.assignment.domain.review.dto.request.ReviewCreateRequest;
+import org.c4marathon.assignment.domain.review.entity.ReviewFactory;
+import org.c4marathon.assignment.domain.review.service.ReviewService;
+import org.c4marathon.assignment.domain.service.ServiceTestSupport;
+import org.c4marathon.assignment.global.error.BaseException;
+import org.c4marathon.assignment.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+public class ReviewServiceTest extends ServiceTestSupport {
+
+	@InjectMocks
+	private ReviewService reviewService;
+	@Mock
+	private ProductReadService productReadService;
+
+	@DisplayName("리뷰 작성 시")
+	@Nested
+	class CreateReview {
+
+		@DisplayName("처음 리뷰를 작성하는 것이라면, review entity가 생성되고 product의 avgScore가 수정된다.")
+		@Test
+		void updateAvgScore_when_createReview() {
+			ReviewCreateRequest request = new ReviewCreateRequest(3, "comment", 1);
+
+			given(productReadService.findById(anyLong()))
+				.willReturn(product);
+			given(product.getAvgScore())
+				.willReturn(0.0);
+			given(productReadService.findReviewCount(anyLong()))
+				.willReturn(0L);
+
+			reviewService.createReview(consumer, request);
+
+			then(product)
+				.should(times(1))
+				.updateAvgScore(anyDouble());
+			then(reviewRepository)
+				.should(times(1))
+				.save(any());
+		}
+
+		@DisplayName("중복 리뷰는 불가능하다.")
+		@Test
+		void fail_when_duplicateReview() {
+			ReviewCreateRequest request = new ReviewCreateRequest(3, "comment", 1);
+
+			given(reviewRepository.existsByConsumerIdAndProductId(anyLong(), anyLong()))
+				.willReturn(true);
+
+			ErrorCode errorCode = ErrorCode.REVIEW_ALREADY_EXISTS;
+			BaseException exception = new BaseException(errorCode.name(), errorCode.getMessage());
+			assertThatThrownBy(() -> reviewService.createReview(consumer, request))
+				.isInstanceOf(exception.getClass())
+				.hasMessageMatching(exception.getMessage());
+		}
+	}
+}

--- a/src/test/java/org/c4marathon/assignment/domain/service/review/ReviewServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/domain/service/review/ReviewServiceTest.java
@@ -3,6 +3,8 @@ package org.c4marathon.assignment.domain.service.review;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.math.BigDecimal;
+
 import org.c4marathon.assignment.domain.orderproduct.service.OrderProductReadService;
 import org.c4marathon.assignment.domain.product.service.ProductReadService;
 import org.c4marathon.assignment.domain.review.dto.request.ReviewCreateRequest;
@@ -35,15 +37,15 @@ public class ReviewServiceTest extends ServiceTestSupport {
 			ReviewCreateRequest request = new ReviewCreateRequest(3, "comment", 1);
 
 			given(productReadService.findById(anyLong())).willReturn(product);
-			given(product.getAvgScore()).willReturn(0.0);
-			given(productReadService.findReviewCount(anyLong())).willReturn(0L);
+			given(product.getAvgScore()).willReturn(BigDecimal.ZERO);
+			given(reviewRepository.countByProductId(anyLong())).willReturn(0L);
 			given(orderProductReadService.existsByConsumerIdAndProductId(anyLong(), anyLong())).willReturn(true);
 
 			reviewService.createReview(consumer, request);
 
 			then(product)
 				.should(times(1))
-				.updateAvgScore(anyDouble());
+				.updateAvgScore(any(BigDecimal.class));
 			then(reviewRepository)
 				.should(times(1))
 				.save(any());

--- a/src/test/java/org/c4marathon/assignment/domain/service/review/ReviewServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/domain/service/review/ReviewServiceTest.java
@@ -5,7 +5,6 @@ import static org.mockito.BDDMockito.*;
 
 import org.c4marathon.assignment.domain.product.service.ProductReadService;
 import org.c4marathon.assignment.domain.review.dto.request.ReviewCreateRequest;
-import org.c4marathon.assignment.domain.review.entity.ReviewFactory;
 import org.c4marathon.assignment.domain.review.service.ReviewService;
 import org.c4marathon.assignment.domain.service.ServiceTestSupport;
 import org.c4marathon.assignment.global.error.BaseException;


### PR DESCRIPTION
### 리뷰 작성
- 해당 상품에 대한 구매 이력이 있는 경우, 리뷰를 작성하지 않은 경우만 리뷰 작성 가능
- 리뷰가 작성되면, 리뷰를 작성한 상품의 avgScore가 변경됩니다.

### 상품 검색
- SortType(NEWEST, PRICE_ASC, PRICE_DESC, POPULARITY, TOP_RATED) 기준으로 5개의 쿼리를 직접 작성했습니다.
- Querydsl을 사용할까도 고민했는데 제 경험상으로는 동적 쿼리에 대한 코드가 딱히 엄청나게 줄어든다는 느낌은 받지 못해서 사용하지 않았습니다.
- 각 쿼리는 pagination이 적용돼 있고, 모든 검색 조건 컬럼은 중복이 가능하기 때문에 product_id 컬럼과 함께 multi column pagination을 적용했습니다.

product 10만개, review 150만개, order_product 600만개, pageSize = 100 기준으로,
- 가격 낮은/높은 순과 최신 순은 Product의 컬럼으로만 조회가 가능해서 수십 ms 이내로 조회가 가능하지만, 구매 많은 순과 별점 높은 순은 조인을 하거나, 쿼리를 여러 번 수행해야 해서 수백 ms ~ 수 초가 걸렸습니다.
- 구매 많은 순은 count 쿼리를 잘 이용하면 100ms 대에 처리가 가능했지만 특히, 별점 높은 순은 review_tbl에 대해서 집계 쿼리를 사용해야만 해서 너무 오래 걸렸습니다.
- 커버링 인덱스를 적절히 넣어도 1초 이내로 끊을 수 없었습니다.
<br>

<img width="590" alt="image" src="https://github.com/C4-ComeTrue/c4-cometrue-assignment/assets/73534426/b3ccb918-f12c-4d91-83ff-54c334f42dbf">

- 그래서 조회 성능을 끌어 올리기 위해서 product_tbl에 avg_score와 order_count 컬럼을 추가로 둬서 리뷰 추가 시, 구매 확정 시에 해당 컬럼들을 수정하도록 했습니다.
- 결론적으로 모든 쿼리가 수십 ms 이내로 조회가 가능해졌습니다.
