### PR TITLE
Feature/hellozo0 step1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### MAC ###
 .DS_Store
+
+### Redis ###
+dump.rdb

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,11 @@ dependencies {
     //mysql
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    //redis
+//    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+//    implementation 'org.springframework.session:spring-session-data-redis'
+//    implementation 'org.springframework.boot:spring-boot-starter-cache'
+
     //test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 
     //apache
     implementation 'org.apache.commons:commons-lang3:3.13.0'
@@ -42,9 +43,8 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     //redis
-//    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-//    implementation 'org.springframework.session:spring-session-data-redis'
-//    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.session:spring-session-data-redis'
 
     //test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/org/c4marathon/assignment/AssignmentApplication.java
+++ b/src/main/java/org/c4marathon/assignment/AssignmentApplication.java
@@ -2,8 +2,12 @@ package org.c4marathon.assignment;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
+@EnableCaching
 public class AssignmentApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/c4marathon/assignment/AssignmentApplication.java
+++ b/src/main/java/org/c4marathon/assignment/AssignmentApplication.java
@@ -4,8 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 @EnableJpaAuditing
 @EnableCaching
 public class AssignmentApplication {

--- a/src/main/java/org/c4marathon/assignment/common/cache/CacheConfig.java
+++ b/src/main/java/org/c4marathon/assignment/common/cache/CacheConfig.java
@@ -1,0 +1,22 @@
+package org.c4marathon.assignment.common.cache;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class CacheConfig {
+
+	@Bean
+	public RedisTemplate<String, Long> redisStringLongTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, Long> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(new GenericToStringSerializer<>(Long.class));
+
+		return template;
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/common/cache/CacheScheduler.java
+++ b/src/main/java/org/c4marathon/assignment/common/cache/CacheScheduler.java
@@ -1,0 +1,30 @@
+package org.c4marathon.assignment.common.cache;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CacheScheduler {
+	private final RedisTemplate<String, Long> redisTemplate;
+
+	public CacheScheduler(RedisTemplate<String, Long> redisTemplate) {
+		this.redisTemplate = redisTemplate;
+	}
+
+	@Scheduled(cron = "0 0 0 * * *")
+	public void resetDailyLimit() {
+		/* 24시에 10분동안 은행 계좌 점검 => 10분동안 일일 한도 초기화 */
+		String lockKey = "reset";
+		redisTemplate.opsForValue().set(lockKey, 1L, Duration.ofMinutes(10));
+
+		/* 모든 dailyLimit 삭제 */
+		try {
+			redisTemplate.keys("dailyLimit:*").forEach(redisTemplate::delete);
+		} finally {
+			redisTemplate.delete(lockKey);
+		}
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/common/dto/ErrorResponse.java
+++ b/src/main/java/org/c4marathon/assignment/common/dto/ErrorResponse.java
@@ -1,0 +1,25 @@
+package org.c4marathon.assignment.common.dto;
+
+import org.c4marathon.assignment.common.exception.enums.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ErrorResponse {
+	private final int code;
+	private final String message;
+
+	public static ErrorResponse error(ErrorCode errorCode) {
+		return new ErrorResponse(errorCode.getHttpStatus().value(), errorCode.getMessage());
+	}
+
+	public static ErrorResponse badRequestError(final String errorMessage) {
+		return new ErrorResponse(HttpStatus.BAD_REQUEST.value(), errorMessage);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/common/dto/SuccessNonDataResponse.java
+++ b/src/main/java/org/c4marathon/assignment/common/dto/SuccessNonDataResponse.java
@@ -1,0 +1,20 @@
+package org.c4marathon.assignment.common.dto;
+
+import org.c4marathon.assignment.common.exception.enums.SuccessCode;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SuccessNonDataResponse {
+	private final int code;
+	private final String message;
+
+	public static SuccessNonDataResponse success(SuccessCode successCode) {
+		return new SuccessNonDataResponse(successCode.getHttpStatus().value(), successCode.getMessage());
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/common/dto/SuccessResponse.java
+++ b/src/main/java/org/c4marathon/assignment/common/dto/SuccessResponse.java
@@ -1,0 +1,21 @@
+package org.c4marathon.assignment.common.dto;
+
+import org.c4marathon.assignment.common.exception.enums.SuccessCode;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SuccessResponse<T> {
+	private final int code;
+	private final String message;
+	private final T data;
+
+	public static <T> SuccessResponse<T> success(SuccessCode successCode, T data) {
+		return new SuccessResponse<>(successCode.getHttpStatus().value(), successCode.getMessage(), data);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/common/exception/BalanceUpdateException.java
+++ b/src/main/java/org/c4marathon/assignment/common/exception/BalanceUpdateException.java
@@ -1,0 +1,9 @@
+package org.c4marathon.assignment.common.exception;
+
+import org.c4marathon.assignment.common.exception.enums.ErrorCode;
+
+public class BalanceUpdateException extends BaseException {
+	public BalanceUpdateException(ErrorCode errorCode) {
+      super(errorCode);
+    }
+}

--- a/src/main/java/org/c4marathon/assignment/common/exception/BaseException.java
+++ b/src/main/java/org/c4marathon/assignment/common/exception/BaseException.java
@@ -1,0 +1,14 @@
+package org.c4marathon.assignment.common.exception;
+
+import org.c4marathon.assignment.common.exception.enums.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class BaseException extends RuntimeException {
+	private final ErrorCode errorCode;
+
+	public BaseException(final ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/common/exception/NotFoundException.java
+++ b/src/main/java/org/c4marathon/assignment/common/exception/NotFoundException.java
@@ -1,0 +1,9 @@
+package org.c4marathon.assignment.common.exception;
+
+import org.c4marathon.assignment.common.exception.enums.ErrorCode;
+
+public class NotFoundException extends BaseException {
+    public NotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/c4marathon/assignment/common/exception/enums/ErrorCode.java
+++ b/src/main/java/org/c4marathon/assignment/common/exception/enums/ErrorCode.java
@@ -8,7 +8,11 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 	//404
-	NOT_FOUND_MAIN_ACCOUNT(HttpStatus.NOT_FOUND, "메인 계좌가 존재하지 않습니다.");
+	NOT_FOUND_MAIN_ACCOUNT(HttpStatus.NOT_FOUND, "메인 계좌가 존재하지 않습니다."),
+	//409
+	DAILY_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "일일 한도를 초과했습니다."),
+	REDIS_RESET_EXCEPTION(HttpStatus.CONFLICT, "일일 한도 초기화 중입니다."),
+	FAILED_BALANCE_UPDATE(HttpStatus.CONFLICT, "잔고 업데이트에 실패했습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/org/c4marathon/assignment/common/exception/enums/ErrorCode.java
+++ b/src/main/java/org/c4marathon/assignment/common/exception/enums/ErrorCode.java
@@ -9,10 +9,12 @@ import lombok.Getter;
 public enum ErrorCode {
 	//404
 	NOT_FOUND_MAIN_ACCOUNT(HttpStatus.NOT_FOUND, "메인 계좌가 존재하지 않습니다."),
+	NOT_FOUND_SAVING_ACCOUNT(HttpStatus.NOT_FOUND, "적금 계좌가 존재하지 않습니다."),
 	//409
 	DAILY_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "일일 한도를 초과했습니다."),
 	REDIS_RESET_EXCEPTION(HttpStatus.CONFLICT, "일일 한도 초기화 중입니다."),
-	FAILED_BALANCE_UPDATE(HttpStatus.CONFLICT, "잔고 업데이트에 실패했습니다.");
+	FAILED_BALANCE_UPDATE(HttpStatus.CONFLICT, "잔고 업데이트에 실패했습니다."),
+	BALANCE_NOT_ENOUGH(HttpStatus.CONFLICT, "잔고 부족으로 실패했습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/org/c4marathon/assignment/common/exception/enums/ErrorCode.java
+++ b/src/main/java/org/c4marathon/assignment/common/exception/enums/ErrorCode.java
@@ -1,0 +1,15 @@
+package org.c4marathon.assignment.common.exception.enums;
+
+import org.springframework.http.HttpStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+	//404
+	NOT_FOUND_MAIN_ACCOUNT(HttpStatus.NOT_FOUND, "메인 계좌가 존재하지 않습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/org/c4marathon/assignment/common/exception/enums/SuccessCode.java
+++ b/src/main/java/org/c4marathon/assignment/common/exception/enums/SuccessCode.java
@@ -1,0 +1,16 @@
+package org.c4marathon.assignment.common.exception.enums;
+
+import org.springframework.http.HttpStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessCode {
+
+	CHARGE_MAIN_ACCOUNT_SUCCESS(HttpStatus.OK, "메인 계좌에 충전 완료되었습니다."),
+	TRANSFER_SAVING_ACCOUNT_SUCCESS(HttpStatus.OK, "적금 계좌에 송금 완료되었습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/org/c4marathon/assignment/common/exception/enums/SuccessCode.java
+++ b/src/main/java/org/c4marathon/assignment/common/exception/enums/SuccessCode.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SuccessCode {
 
+	CREATE_MAIN_ACCOUNT_SUCCESS(HttpStatus.CREATED, "메인 계좌 생성이 완료되었습니다."),
+	CREATE_SAVING_ACCOUNT_SUCCESS(HttpStatus.CREATED, "적금 계좌 생성이 완료되었습니다."),
 	CHARGE_MAIN_ACCOUNT_SUCCESS(HttpStatus.OK, "메인 계좌에 충전 완료되었습니다."),
 	TRANSFER_SAVING_ACCOUNT_SUCCESS(HttpStatus.OK, "적금 계좌에 송금 완료되었습니다.");
 

--- a/src/main/java/org/c4marathon/assignment/common/util/BankSystemUtil.java
+++ b/src/main/java/org/c4marathon/assignment/common/util/BankSystemUtil.java
@@ -1,0 +1,29 @@
+package org.c4marathon.assignment.common.util;
+
+import java.util.Random;
+
+public class BankSystemUtil {
+	private static final String BANK_CODE = "3333";
+
+	/**
+	 * 계좌 번호 생성
+	 * */
+	public static String createAccountNumber(int counter){
+		Random random = new Random();
+		int createNum = 0;
+		String ranNum = "";
+		String randomNum = "";
+
+		for (int i=0; i<7; i++) {
+			createNum = random.nextInt(9);
+			ranNum = Integer.toString(createNum);
+			randomNum += ranNum;
+		}
+		String bankNum = "3333";
+		String countAccountNum = String.format("%02d",counter);
+
+		counter++;
+		String accountNum = bankNum+"-"+countAccountNum+"-"+randomNum;
+		return accountNum;
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/controller/MainAccountController.java
+++ b/src/main/java/org/c4marathon/assignment/controller/MainAccountController.java
@@ -1,0 +1,12 @@
+package org.c4marathon.assignment.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/mainAccount")
+@RequiredArgsConstructor
+public class MainAccountController {
+}

--- a/src/main/java/org/c4marathon/assignment/controller/MainAccountController.java
+++ b/src/main/java/org/c4marathon/assignment/controller/MainAccountController.java
@@ -2,11 +2,10 @@ package org.c4marathon.assignment.controller;
 
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/mainAccount")
+@RequestMapping("/account/main")
 @RequiredArgsConstructor
 public class MainAccountController {
 }

--- a/src/main/java/org/c4marathon/assignment/controller/MainAccountController.java
+++ b/src/main/java/org/c4marathon/assignment/controller/MainAccountController.java
@@ -1,11 +1,24 @@
 package org.c4marathon.assignment.controller;
 
+import org.c4marathon.assignment.dto.request.ChargeMainAccountRequestDto;
+import org.c4marathon.assignment.service.MainAccountService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/account/main")
 @RequiredArgsConstructor
 public class MainAccountController {
+
+	private final MainAccountService mainAccountService;
+
+	@PostMapping("/charge")
+	public void chargeMainAccount(@RequestBody @Valid ChargeMainAccountRequestDto requestDto){
+		mainAccountService.chargeMainAccount(requestDto);
+	}
 }

--- a/src/main/java/org/c4marathon/assignment/controller/MainAccountController.java
+++ b/src/main/java/org/c4marathon/assignment/controller/MainAccountController.java
@@ -1,5 +1,7 @@
 package org.c4marathon.assignment.controller;
 
+import org.c4marathon.assignment.common.dto.SuccessNonDataResponse;
+import org.c4marathon.assignment.common.exception.enums.SuccessCode;
 import org.c4marathon.assignment.dto.request.ChargeMainAccountRequestDto;
 import org.c4marathon.assignment.service.MainAccountService;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,7 +20,8 @@ public class MainAccountController {
 	private final MainAccountService mainAccountService;
 
 	@PostMapping("/charge")
-	public void chargeMainAccount(@RequestBody @Valid ChargeMainAccountRequestDto requestDto){
+	public SuccessNonDataResponse chargeMainAccount(@RequestBody @Valid ChargeMainAccountRequestDto requestDto){
 		mainAccountService.chargeMainAccount(requestDto);
+		return SuccessNonDataResponse.success(SuccessCode.CHARGE_MAIN_ACCOUNT_SUCCESS);
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/controller/SavingAccountController.java
+++ b/src/main/java/org/c4marathon/assignment/controller/SavingAccountController.java
@@ -1,5 +1,6 @@
 package org.c4marathon.assignment.controller;
 
+import org.c4marathon.assignment.dto.request.ChargeSavingAccountRequestDto;
 import org.c4marathon.assignment.dto.request.SavingAccountRequestDto;
 import org.c4marathon.assignment.service.SavingAccountService;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,5 +20,10 @@ public class SavingAccountController {
 	@PostMapping()
 	public void createSavingAccount(@RequestBody @Valid SavingAccountRequestDto requestDto){
 		savingAccountService.createSavingAccount(requestDto);
+	}
+
+	@PostMapping("/charge")
+	public void chargeFromMainAccount(@RequestBody @Valid ChargeSavingAccountRequestDto requestDto){
+		savingAccountService.chargeFromMainAccount(requestDto);
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/controller/SavingAccountController.java
+++ b/src/main/java/org/c4marathon/assignment/controller/SavingAccountController.java
@@ -1,5 +1,7 @@
 package org.c4marathon.assignment.controller;
 
+import org.c4marathon.assignment.common.dto.SuccessNonDataResponse;
+import org.c4marathon.assignment.common.exception.enums.SuccessCode;
 import org.c4marathon.assignment.dto.request.ChargeSavingAccountRequestDto;
 import org.c4marathon.assignment.dto.request.SavingAccountRequestDto;
 import org.c4marathon.assignment.service.SavingAccountService;
@@ -18,12 +20,14 @@ public class SavingAccountController {
 	private final SavingAccountService savingAccountService;
 
 	@PostMapping()
-	public void createSavingAccount(@RequestBody @Valid SavingAccountRequestDto requestDto){
+	public SuccessNonDataResponse createSavingAccount(@RequestBody @Valid SavingAccountRequestDto requestDto){
 		savingAccountService.createSavingAccount(requestDto);
+		return SuccessNonDataResponse.success(SuccessCode.CREATE_SAVING_ACCOUNT_SUCCESS);
 	}
 
 	@PostMapping("/charge")
-	public void chargeFromMainAccount(@RequestBody @Valid ChargeSavingAccountRequestDto requestDto){
+	public SuccessNonDataResponse chargeFromMainAccount(@RequestBody @Valid ChargeSavingAccountRequestDto requestDto){
 		savingAccountService.chargeFromMainAccount(requestDto);
+		return SuccessNonDataResponse.success(SuccessCode.TRANSFER_SAVING_ACCOUNT_SUCCESS);
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/controller/SavingAccountController.java
+++ b/src/main/java/org/c4marathon/assignment/controller/SavingAccountController.java
@@ -1,0 +1,23 @@
+package org.c4marathon.assignment.controller;
+
+import org.c4marathon.assignment.dto.request.SavingAccountRequestDto;
+import org.c4marathon.assignment.service.SavingAccountService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/account/saving")
+@RequiredArgsConstructor
+public class SavingAccountController {
+
+	private final SavingAccountService savingAccountService;
+
+	@PostMapping()
+	public void createSavingAccount(@RequestBody @Valid SavingAccountRequestDto requestDto){
+		savingAccountService.createSavingAccount(requestDto);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/controller/UserController.java
+++ b/src/main/java/org/c4marathon/assignment/controller/UserController.java
@@ -1,5 +1,7 @@
 package org.c4marathon.assignment.controller;
 
+import org.c4marathon.assignment.common.dto.SuccessNonDataResponse;
+import org.c4marathon.assignment.common.exception.enums.SuccessCode;
 import org.c4marathon.assignment.dto.request.SignUpRequestDto;
 import org.c4marathon.assignment.service.UserService;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,7 +19,8 @@ public class UserController {
 	private final UserService userService;
 
 	@PostMapping("/signup")
-	public void signUp(@RequestBody @Valid SignUpRequestDto requestDto){
+	public SuccessNonDataResponse signUp(@RequestBody @Valid SignUpRequestDto requestDto){
 		userService.signUp(requestDto);
+		return SuccessNonDataResponse.success(SuccessCode.CREATE_MAIN_ACCOUNT_SUCCESS);
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/controller/UserController.java
+++ b/src/main/java/org/c4marathon/assignment/controller/UserController.java
@@ -6,7 +6,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/org/c4marathon/assignment/controller/UserController.java
+++ b/src/main/java/org/c4marathon/assignment/controller/UserController.java
@@ -1,0 +1,24 @@
+package org.c4marathon.assignment.controller;
+
+import org.c4marathon.assignment.dto.request.SignUpRequestDto;
+import org.c4marathon.assignment.service.UserService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/user")
+@RequiredArgsConstructor
+public class UserController {
+
+	private final UserService userService;
+
+	@PostMapping("/signup")
+	public void signUp(@RequestBody @Valid SignUpRequestDto requestDto){
+		userService.signUp(requestDto);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/BaseEntity.java
+++ b/src/main/java/org/c4marathon/assignment/domain/BaseEntity.java
@@ -1,0 +1,28 @@
+package org.c4marathon.assignment.domain;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@EntityListeners(value = AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public class BaseEntity {
+	@NotNull
+	@CreatedDate
+	@Column(name = "create_date", nullable = false, updatable = false)
+	private LocalDateTime createDate;
+
+	@NotNull
+	@LastModifiedDate
+	@Column(name = "update_date", nullable = false)
+	private LocalDateTime updateDate;
+}

--- a/src/main/java/org/c4marathon/assignment/domain/MainAccount.java
+++ b/src/main/java/org/c4marathon/assignment/domain/MainAccount.java
@@ -45,4 +45,8 @@ public class MainAccount extends BaseEntity{
 	public void chargeMoney(long money) {
 		this.balance += money;
 	}
+
+	public void withdrawMoney(long money){
+		this.balance -= money;
+	}
 }

--- a/src/main/java/org/c4marathon/assignment/domain/MainAccount.java
+++ b/src/main/java/org/c4marathon/assignment/domain/MainAccount.java
@@ -45,4 +45,9 @@ public class MainAccount extends BaseEntity{
 	public void withdrawMoney(long money){
 		this.balance -= money;
 	}
+
+	public boolean checkBalanceAvailability(long money){
+		return this.balance >= money;
+	}
+
 }

--- a/src/main/java/org/c4marathon/assignment/domain/MainAccount.java
+++ b/src/main/java/org/c4marathon/assignment/domain/MainAccount.java
@@ -1,0 +1,42 @@
+package org.c4marathon.assignment.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "main_account")
+@Getter
+@NoArgsConstructor
+public class MainAccount {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "main_account_id", nullable = false)
+	private Integer id;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Column(name = "account_number", nullable = false, length = 15)
+	private String accountNumber;
+
+	@Column(name = "balance", nullable = false)
+	private int balance;
+
+	@Column(name = "limit", nullable = false)
+	private int limit;
+
+	@Column(name = "create_date", nullable = false)
+	private LocalDateTime createDate;
+}

--- a/src/main/java/org/c4marathon/assignment/domain/MainAccount.java
+++ b/src/main/java/org/c4marathon/assignment/domain/MainAccount.java
@@ -1,7 +1,5 @@
 package org.c4marathon.assignment.domain;
 
-import java.time.LocalDateTime;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -18,11 +16,11 @@ import lombok.NoArgsConstructor;
 @Table(name = "main_account")
 @Getter
 @NoArgsConstructor
-public class MainAccount {
+public class MainAccount extends BaseEntity{
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "main_account_id", nullable = false)
-	private Integer id;
+	private long id;
 
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
@@ -34,9 +32,13 @@ public class MainAccount {
 	@Column(name = "balance", nullable = false)
 	private int balance;
 
-	@Column(name = "limit", nullable = false)
+	@Column(name = "account_limit", nullable = false)
 	private int limit;
 
-	@Column(name = "create_date", nullable = false)
-	private LocalDateTime createDate;
+	public MainAccount(User user, String accountNumber, int balance, int limit){
+		this.user = user;
+		this.accountNumber = accountNumber;
+		this.balance = balance;
+		this.limit = limit;
+	}
 }

--- a/src/main/java/org/c4marathon/assignment/domain/MainAccount.java
+++ b/src/main/java/org/c4marathon/assignment/domain/MainAccount.java
@@ -32,14 +32,10 @@ public class MainAccount extends BaseEntity{
 	@Column(name = "balance", nullable = false)
 	private long balance;
 
-	@Column(name = "account_limit", nullable = false)
-	private long limit;
-
-	public MainAccount(User user, String accountNumber, long balance, long limit){
+	public MainAccount(User user, String accountNumber, long balance){
 		this.user = user;
 		this.accountNumber = accountNumber;
 		this.balance = balance;
-		this.limit = limit;
 	}
 
 	public void chargeMoney(long money) {

--- a/src/main/java/org/c4marathon/assignment/domain/MainAccount.java
+++ b/src/main/java/org/c4marathon/assignment/domain/MainAccount.java
@@ -30,10 +30,10 @@ public class MainAccount extends BaseEntity{
 	private String accountNumber;
 
 	@Column(name = "balance", nullable = false)
-	private int balance;
+	private double balance;
 
 	@Column(name = "account_limit", nullable = false)
-	private int limit;
+	private double limit;
 
 	public MainAccount(User user, String accountNumber, int balance, int limit){
 		this.user = user;

--- a/src/main/java/org/c4marathon/assignment/domain/MainAccount.java
+++ b/src/main/java/org/c4marathon/assignment/domain/MainAccount.java
@@ -30,15 +30,19 @@ public class MainAccount extends BaseEntity{
 	private String accountNumber;
 
 	@Column(name = "balance", nullable = false)
-	private double balance;
+	private long balance;
 
 	@Column(name = "account_limit", nullable = false)
-	private double limit;
+	private long limit;
 
-	public MainAccount(User user, String accountNumber, int balance, int limit){
+	public MainAccount(User user, String accountNumber, long balance, long limit){
 		this.user = user;
 		this.accountNumber = accountNumber;
 		this.balance = balance;
 		this.limit = limit;
+	}
+
+	public void chargeMoney(long money) {
+		this.balance += money;
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/domain/SavingAccount.java
+++ b/src/main/java/org/c4marathon/assignment/domain/SavingAccount.java
@@ -30,8 +30,15 @@ public class SavingAccount extends BaseEntity {
 	private String accountNumber;
 
 	@Column(name = "balance", nullable = false)
-	private int balance;
+	private double balance;
 
 	@Column(name = "rate", nullable = false)
 	private double rate;
+
+	public SavingAccount(MainAccount mainAccount, String accountNumber, double balance, double rate){
+		this.mainAccount = mainAccount;
+		this.accountNumber = accountNumber;
+		this.balance = balance;
+		this.rate = rate;
+	}
 }

--- a/src/main/java/org/c4marathon/assignment/domain/SavingAccount.java
+++ b/src/main/java/org/c4marathon/assignment/domain/SavingAccount.java
@@ -30,12 +30,12 @@ public class SavingAccount extends BaseEntity {
 	private String accountNumber;
 
 	@Column(name = "balance", nullable = false)
-	private double balance;
+	private long balance;
 
 	@Column(name = "rate", nullable = false)
 	private double rate;
 
-	public SavingAccount(MainAccount mainAccount, String accountNumber, double balance, double rate){
+	public SavingAccount(MainAccount mainAccount, String accountNumber, long balance, double rate){
 		this.mainAccount = mainAccount;
 		this.accountNumber = accountNumber;
 		this.balance = balance;

--- a/src/main/java/org/c4marathon/assignment/domain/SavingAccount.java
+++ b/src/main/java/org/c4marathon/assignment/domain/SavingAccount.java
@@ -41,4 +41,8 @@ public class SavingAccount extends BaseEntity {
 		this.balance = balance;
 		this.rate = rate;
 	}
+
+	public void chargeMoney(long money) {
+		this.balance += money;
+	}
 }

--- a/src/main/java/org/c4marathon/assignment/domain/SavingAccount.java
+++ b/src/main/java/org/c4marathon/assignment/domain/SavingAccount.java
@@ -1,0 +1,42 @@
+package org.c4marathon.assignment.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "saving_account")
+@Getter
+@NoArgsConstructor
+public class SavingAccount {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "saving_account_id", nullable = false)
+	private Integer id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "main_account_id", nullable = false)
+	private MainAccount mainAccount;
+
+	@Column(name = "account_number", nullable = false, length = 15)
+	private String accountNumber;
+
+	@Column(name = "balance", nullable = false)
+	private int balance;
+
+	@Column(name = "rate", nullable = false)
+	private double rate;
+
+	@Column(name = "create_date", nullable = false)
+	private LocalDateTime createDate;
+}

--- a/src/main/java/org/c4marathon/assignment/domain/SavingAccount.java
+++ b/src/main/java/org/c4marathon/assignment/domain/SavingAccount.java
@@ -1,7 +1,5 @@
 package org.c4marathon.assignment.domain;
 
-import java.time.LocalDateTime;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -18,11 +16,11 @@ import lombok.NoArgsConstructor;
 @Table(name = "saving_account")
 @Getter
 @NoArgsConstructor
-public class SavingAccount {
+public class SavingAccount extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "saving_account_id", nullable = false)
-	private Integer id;
+	private long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "main_account_id", nullable = false)
@@ -36,7 +34,4 @@ public class SavingAccount {
 
 	@Column(name = "rate", nullable = false)
 	private double rate;
-
-	@Column(name = "create_date", nullable = false)
-	private LocalDateTime createDate;
 }

--- a/src/main/java/org/c4marathon/assignment/domain/User.java
+++ b/src/main/java/org/c4marathon/assignment/domain/User.java
@@ -1,0 +1,32 @@
+package org.c4marathon.assignment.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user")
+@Getter
+@NoArgsConstructor
+public class User {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "user_id", nullable = false)
+	private Integer id;
+
+	@Column(name = "username", nullable = false, length = 30)
+	private String username;
+
+	@Column(name = "create_date", nullable = false)
+	private LocalDateTime  createDate;
+
+	@Column(name = "update_date", nullable = false)
+	private LocalDateTime updateDate;
+}

--- a/src/main/java/org/c4marathon/assignment/domain/User.java
+++ b/src/main/java/org/c4marathon/assignment/domain/User.java
@@ -1,7 +1,5 @@
 package org.c4marathon.assignment.domain;
 
-import java.time.LocalDateTime;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -15,18 +13,17 @@ import lombok.NoArgsConstructor;
 @Table(name = "user")
 @Getter
 @NoArgsConstructor
-public class User {
+public class User extends BaseEntity{
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "user_id", nullable = false)
-	private Integer id;
+	private long id;
 
 	@Column(name = "username", nullable = false, length = 30)
 	private String username;
 
-	@Column(name = "create_date", nullable = false)
-	private LocalDateTime  createDate;
+	public User(String username) {
+		this.username = username;
+	}
 
-	@Column(name = "update_date", nullable = false)
-	private LocalDateTime updateDate;
 }

--- a/src/main/java/org/c4marathon/assignment/dto/request/ChargeMainAccountRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/dto/request/ChargeMainAccountRequestDto.java
@@ -1,0 +1,13 @@
+package org.c4marathon.assignment.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record ChargeMainAccountRequestDto(
+	@NotNull(message = "메인계좌 id를 입력해주세요.")
+	long mainAccountId,
+	@NotNull(message = "충전 할 금액을 입력해주세요.")
+	@PositiveOrZero(message = "0원 이상을 입력해주세요.")
+	long money
+) {
+}

--- a/src/main/java/org/c4marathon/assignment/dto/request/ChargeMainAccountRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/dto/request/ChargeMainAccountRequestDto.java
@@ -4,9 +4,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 
 public record ChargeMainAccountRequestDto(
-	@NotNull(message = "메인계좌 id를 입력해주세요.")
 	long mainAccountId,
-	@NotNull(message = "충전 할 금액을 입력해주세요.")
 	@PositiveOrZero(message = "0원 이상을 입력해주세요.")
 	long money
 ) {

--- a/src/main/java/org/c4marathon/assignment/dto/request/ChargeSavingAccountRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/dto/request/ChargeSavingAccountRequestDto.java
@@ -1,0 +1,15 @@
+package org.c4marathon.assignment.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record ChargeSavingAccountRequestDto(
+	@NotNull(message = "메인계좌 id를 입력해주세요.")
+	long mainAccountId,
+	@NotNull(message = "적금계좌 id를 입력해주세요.")
+	long savingAccountId,
+	@NotNull(message = "충전 할 금액을 입력해주세요.")
+	@PositiveOrZero(message = "0원 이상을 입력해주세요.")
+	long money
+) {
+}

--- a/src/main/java/org/c4marathon/assignment/dto/request/ChargeSavingAccountRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/dto/request/ChargeSavingAccountRequestDto.java
@@ -4,11 +4,8 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 
 public record ChargeSavingAccountRequestDto(
-	@NotNull(message = "메인계좌 id를 입력해주세요.")
 	long mainAccountId,
-	@NotNull(message = "적금계좌 id를 입력해주세요.")
 	long savingAccountId,
-	@NotNull(message = "충전 할 금액을 입력해주세요.")
 	@PositiveOrZero(message = "0원 이상을 입력해주세요.")
 	long money
 ) {

--- a/src/main/java/org/c4marathon/assignment/dto/request/SavingAccountRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/dto/request/SavingAccountRequestDto.java
@@ -3,11 +3,8 @@ package org.c4marathon.assignment.dto.request;
 import jakarta.validation.constraints.NotNull;
 
 public record SavingAccountRequestDto(
-	@NotNull(message = "메인계좌 id를 입력해주세요.")
 	long mainAccountId,
-	@NotNull(message = "초기금액을 입력해주세요.")
 	long balance,
-	@NotNull(message = "이율을 입력해주세요.")
 	double rate
 ) {
 }

--- a/src/main/java/org/c4marathon/assignment/dto/request/SavingAccountRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/dto/request/SavingAccountRequestDto.java
@@ -1,0 +1,13 @@
+package org.c4marathon.assignment.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record SavingAccountRequestDto(
+	@NotNull(message = "메인계좌 id를 입력해주세요.")
+	long mainAccountId,
+	@NotNull(message = "초기금액을 입력해주세요.")
+	double balance,
+	@NotNull(message = "이율을 입력해주세요.")
+	double rate
+) {
+}

--- a/src/main/java/org/c4marathon/assignment/dto/request/SavingAccountRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/dto/request/SavingAccountRequestDto.java
@@ -6,7 +6,7 @@ public record SavingAccountRequestDto(
 	@NotNull(message = "메인계좌 id를 입력해주세요.")
 	long mainAccountId,
 	@NotNull(message = "초기금액을 입력해주세요.")
-	double balance,
+	long balance,
 	@NotNull(message = "이율을 입력해주세요.")
 	double rate
 ) {

--- a/src/main/java/org/c4marathon/assignment/dto/request/SignUpRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/dto/request/SignUpRequestDto.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Size;
 
 public record SignUpRequestDto(
 	@NotBlank
-	@Size(max = 30)
+	@Size(min = 2, max = 30)
 	String username
 ) {
 }

--- a/src/main/java/org/c4marathon/assignment/dto/request/SignUpRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/dto/request/SignUpRequestDto.java
@@ -1,8 +1,10 @@
 package org.c4marathon.assignment.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record SignUpRequestDto(
+	@NotBlank
 	@Size(max = 30)
 	String username
 ) {

--- a/src/main/java/org/c4marathon/assignment/dto/request/SignUpRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/dto/request/SignUpRequestDto.java
@@ -1,0 +1,9 @@
+package org.c4marathon.assignment.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record SignUpRequestDto(
+	@Size(max = 30)
+	String username
+) {
+}

--- a/src/main/java/org/c4marathon/assignment/repository/MainAccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/repository/MainAccountRepository.java
@@ -1,0 +1,7 @@
+package org.c4marathon.assignment.repository;
+
+import org.c4marathon.assignment.domain.MainAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MainAccountRepository extends JpaRepository<MainAccount, Long> {
+}

--- a/src/main/java/org/c4marathon/assignment/repository/MainAccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/repository/MainAccountRepository.java
@@ -1,7 +1,15 @@
 package org.c4marathon.assignment.repository;
 
+import java.util.Optional;
 import org.c4marathon.assignment.domain.MainAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import jakarta.persistence.LockModeType;
 
 public interface MainAccountRepository extends JpaRepository<MainAccount, Long> {
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT m FROM MainAccount m WHERE m.id = :accountId")
+	Optional<MainAccount> findByIdWithXLock(@Param("accountId") Long accountId);
 }

--- a/src/main/java/org/c4marathon/assignment/repository/SavingAccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/repository/SavingAccountRepository.java
@@ -1,0 +1,7 @@
+package org.c4marathon.assignment.repository;
+
+import org.c4marathon.assignment.domain.SavingAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SavingAccountRepository extends JpaRepository<SavingAccount, Long> {
+}

--- a/src/main/java/org/c4marathon/assignment/repository/SavingAccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/repository/SavingAccountRepository.java
@@ -1,7 +1,15 @@
 package org.c4marathon.assignment.repository;
 
+import java.util.Optional;
 import org.c4marathon.assignment.domain.SavingAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import jakarta.persistence.LockModeType;
 
 public interface SavingAccountRepository extends JpaRepository<SavingAccount, Long> {
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT m FROM SavingAccount m WHERE m.id = :accountId")
+	Optional<SavingAccount> findByIdWithXLock(@Param("accountId") Long accountId);
 }

--- a/src/main/java/org/c4marathon/assignment/repository/UserRepository.java
+++ b/src/main/java/org/c4marathon/assignment/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package org.c4marathon.assignment.repository;
+
+import org.c4marathon.assignment.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/org/c4marathon/assignment/service/MainAccountService.java
+++ b/src/main/java/org/c4marathon/assignment/service/MainAccountService.java
@@ -31,6 +31,19 @@ public class MainAccountService {
 		return mainAccountRepository.findById(mainAccountId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MAIN_ACCOUNT));
 	}
 
+	public MainAccount getMainAccountWithXLock(long mainAccountId){
+		return mainAccountRepository.findByIdWithXLock(mainAccountId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MAIN_ACCOUNT));
+	}
+
+	public void withdrawMoney(MainAccount mainAccount, long money){
+		mainAccount.withdrawMoney(money);
+		mainAccountRepository.save(mainAccount);
+	}
+
+	public boolean checkBalanceAvailability(MainAccount mainAccount, long money){
+		return mainAccount.getBalance() >= money;
+	}
+
 	/**
 	 * 메인 계좌 충전 Method
 	 * [1] Redis를 통해 일일 충전 한도가 넘었는지 확인
@@ -90,7 +103,7 @@ public class MainAccountService {
 	 * */
 	private void updateMainAccountBalance(long mainAccountId, long money){
 		try {
-			MainAccount mainAccount = mainAccountRepository.findByIdWithXLock(mainAccountId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MAIN_ACCOUNT));
+			MainAccount mainAccount = getMainAccountWithXLock(mainAccountId);
 			mainAccount.chargeMoney(money);
 			mainAccountRepository.save(mainAccount);
 		} catch (Exception e){
@@ -109,7 +122,6 @@ public class MainAccountService {
 			redisTemplate.opsForValue().set(key, currentLimit + money);
 		}
 	}
-
 
 	/**
 	 * 계좌 번호 생성

--- a/src/main/java/org/c4marathon/assignment/service/MainAccountService.java
+++ b/src/main/java/org/c4marathon/assignment/service/MainAccountService.java
@@ -1,20 +1,24 @@
 package org.c4marathon.assignment.service;
 
 import java.util.Random;
+
+import org.c4marathon.assignment.common.exception.BalanceUpdateException;
 import org.c4marathon.assignment.common.exception.NotFoundException;
 import org.c4marathon.assignment.common.exception.enums.ErrorCode;
 import org.c4marathon.assignment.domain.MainAccount;
 import org.c4marathon.assignment.domain.User;
+import org.c4marathon.assignment.dto.request.ChargeMainAccountRequestDto;
 import org.c4marathon.assignment.repository.MainAccountRepository;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import lombok.Value;
 
 @Service
 @RequiredArgsConstructor
 public class MainAccountService {
 	private final MainAccountRepository mainAccountRepository;
+	private final RedisTemplate<String,Long> redisTemplate;
 	static int counter = 1;
 
 	@Transactional
@@ -26,6 +30,86 @@ public class MainAccountService {
 	public MainAccount getMainAccount(long mainAccountId){
 		return mainAccountRepository.findById(mainAccountId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MAIN_ACCOUNT));
 	}
+
+	/**
+	 * 메인 계좌 충전 Method
+	 * [1] Redis를 통해 일일 충전 한도가 넘었는지 확인
+	 * [2] balance 업데이트
+	 * [3] balance 업데이트 실패했을때 rollback
+	 * */
+	@Transactional
+	public void chargeMainAccount(ChargeMainAccountRequestDto requestDto){
+
+		/* mainAccountId가 존재하는지 여부 파악 (existId는 Lock을 걸지 않고 조회한다.) */
+		if(!mainAccountRepository.existsById(requestDto.mainAccountId())) {
+			throw new NotFoundException(ErrorCode.NOT_FOUND_MAIN_ACCOUNT);
+		}
+
+		try {
+			if(!validateDailyChargeLimit(requestDto.mainAccountId(), requestDto.money())){
+				throw new IllegalStateException(ErrorCode.DAILY_LIMIT_EXCEEDED.getMessage());
+			}
+			updateMainAccountBalance(requestDto.mainAccountId(), requestDto.money());
+		} catch (Exception e){
+			if(e instanceof BalanceUpdateException){
+				rollbackDailyChargeLimit(requestDto.mainAccountId(), requestDto.money());
+			}
+			throw e;
+		}
+
+	}
+
+	/** [1]
+	 * Redis Cache를 통해 일일 충전한도에 맞는지 여부 확인
+	 * */
+	private boolean validateDailyChargeLimit(long mainAccountId, long money){
+
+		/* 24시에 10분동안 은행 계좌 점검 => 10분동안 일일 한도 초기화*/
+		String lockKey = "reset";
+		if (redisTemplate.hasKey(lockKey)) {
+			throw new IllegalStateException(ErrorCode.REDIS_RESET_EXCEPTION.getMessage());
+		}
+
+		/* Redis에 해당 계좌id가 없다면 일일한도 3,000,000으로 세팅 */
+		Long currentLimit = redisTemplate.opsForValue().get("dailyLimit:"+mainAccountId);
+		if(currentLimit == null) {
+			currentLimit = 3000000L;
+			redisTemplate.opsForValue().set("dailyLimit:" + mainAccountId,currentLimit);
+		}
+
+		/* 일일 한도를 넘었을 경우 */
+		if(currentLimit < money) return false;
+
+		/* 일일 한도를 넘지 않은 경우  */
+		redisTemplate.opsForValue().set("dailyLimit:" + mainAccountId, currentLimit-money);
+		return true;
+	}
+
+	/** [2]
+	 * balance를 update하기 위해서 Lock 을 걸고 조회 수행
+	 * */
+	private void updateMainAccountBalance(long mainAccountId, long money){
+		try {
+			MainAccount mainAccount = mainAccountRepository.findByIdWithXLock(mainAccountId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MAIN_ACCOUNT));
+			mainAccount.chargeMoney(money);
+			mainAccountRepository.save(mainAccount);
+		} catch (Exception e){
+			throw new BalanceUpdateException(ErrorCode.NOT_FOUND_MAIN_ACCOUNT);
+		}
+
+	}
+
+	/** [3]
+	 * balance를 update 실패 했을 때 rollback
+	 * */
+	private void rollbackDailyChargeLimit(long mainAccountId, long money){
+		String key = "dailyLimit:" + mainAccountId;
+		Long currentLimit = redisTemplate.opsForValue().get(key);
+		if (currentLimit != null) {
+			redisTemplate.opsForValue().set(key, currentLimit + money);
+		}
+	}
+
 
 	/**
 	 * 계좌 번호 생성

--- a/src/main/java/org/c4marathon/assignment/service/MainAccountService.java
+++ b/src/main/java/org/c4marathon/assignment/service/MainAccountService.java
@@ -1,0 +1,48 @@
+package org.c4marathon.assignment.service;
+
+import java.beans.Transient;
+import java.util.Random;
+
+import org.c4marathon.assignment.domain.MainAccount;
+import org.c4marathon.assignment.domain.User;
+import org.c4marathon.assignment.repository.MainAccountRepository;
+import org.springframework.stereotype.Service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MainAccountService {
+	private final MainAccountRepository mainAccountRepository;
+	static int counter = 1;
+
+	@Transactional
+	public void createMainAccount(User user){
+		MainAccount mainAccount = new MainAccount(user, createAccountNumber(), 0,3000000);
+		mainAccountRepository.save(mainAccount);
+	}
+
+
+	/**
+	 * 계좌 번호 생성
+	 * */
+	private String createAccountNumber(){
+		Random random = new Random();
+		int createNum = 0;
+		String ranNum = "";
+		String randomNum = "";
+
+		for (int i=0; i<7; i++) {
+			createNum = random.nextInt(9);
+			ranNum = Integer.toString(createNum);
+			randomNum += ranNum;
+		}
+		String bankNum = "3333";
+		String countAccountNum = String.format("%02d",counter);
+
+		counter++;
+		String accountNum = bankNum+"-"+countAccountNum+"-"+randomNum;
+		return accountNum;
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/service/MainAccountService.java
+++ b/src/main/java/org/c4marathon/assignment/service/MainAccountService.java
@@ -23,7 +23,7 @@ public class MainAccountService {
 
 	@Transactional
 	public void createMainAccount(User user){
-		MainAccount mainAccount = new MainAccount(user, createAccountNumber(), 0,3000000);
+		MainAccount mainAccount = new MainAccount(user, createAccountNumber(), 0);
 		mainAccountRepository.save(mainAccount);
 	}
 

--- a/src/main/java/org/c4marathon/assignment/service/SavingAccountService.java
+++ b/src/main/java/org/c4marathon/assignment/service/SavingAccountService.java
@@ -1,30 +1,26 @@
 package org.c4marathon.assignment.service;
 
 import java.util.Random;
-import org.c4marathon.assignment.common.exception.NotFoundException;
-import org.c4marathon.assignment.common.exception.enums.ErrorCode;
 import org.c4marathon.assignment.domain.MainAccount;
-import org.c4marathon.assignment.domain.User;
-import org.c4marathon.assignment.repository.MainAccountRepository;
+import org.c4marathon.assignment.domain.SavingAccount;
+import org.c4marathon.assignment.dto.request.SavingAccountRequestDto;
+import org.c4marathon.assignment.repository.SavingAccountRepository;
 import org.springframework.stereotype.Service;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import lombok.Value;
 
 @Service
 @RequiredArgsConstructor
-public class MainAccountService {
-	private final MainAccountRepository mainAccountRepository;
-	static int counter = 1;
+public class SavingAccountService {
+	private final SavingAccountRepository savingAccountRepository;
+	private final MainAccountService mainAccountService;
+	static int counter = 50;
 
 	@Transactional
-	public void createMainAccount(User user){
-		MainAccount mainAccount = new MainAccount(user, createAccountNumber(), 0,3000000);
-		mainAccountRepository.save(mainAccount);
-	}
-
-	public MainAccount getMainAccount(long mainAccountId){
-		return mainAccountRepository.findById(mainAccountId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MAIN_ACCOUNT));
+	public void createSavingAccount(SavingAccountRequestDto requestDto) {
+		MainAccount mainAccount = mainAccountService.getMainAccount(requestDto.mainAccountId());
+		SavingAccount savingAccount = new SavingAccount(mainAccount, createAccountNumber(), requestDto.balance(), requestDto.rate());
+		savingAccountRepository.save(savingAccount);
 	}
 
 	/**

--- a/src/main/java/org/c4marathon/assignment/service/SavingAccountService.java
+++ b/src/main/java/org/c4marathon/assignment/service/SavingAccountService.java
@@ -5,6 +5,7 @@ import java.util.Random;
 import org.c4marathon.assignment.common.exception.BalanceUpdateException;
 import org.c4marathon.assignment.common.exception.NotFoundException;
 import org.c4marathon.assignment.common.exception.enums.ErrorCode;
+import org.c4marathon.assignment.common.util.BankSystemUtil;
 import org.c4marathon.assignment.domain.MainAccount;
 import org.c4marathon.assignment.domain.SavingAccount;
 import org.c4marathon.assignment.dto.request.ChargeSavingAccountRequestDto;
@@ -24,7 +25,7 @@ public class SavingAccountService {
 	@Transactional
 	public void createSavingAccount(SavingAccountRequestDto requestDto) {
 		MainAccount mainAccount = mainAccountService.getMainAccount(requestDto.mainAccountId());
-		SavingAccount savingAccount = new SavingAccount(mainAccount, createAccountNumber(), requestDto.balance(), requestDto.rate());
+		SavingAccount savingAccount = new SavingAccount(mainAccount, BankSystemUtil.createAccountNumber(counter), requestDto.balance(), requestDto.rate());
 		savingAccountRepository.save(savingAccount);
 	}
 
@@ -40,8 +41,9 @@ public class SavingAccountService {
 		MainAccount mainAccount = mainAccountService.getMainAccountWithXLock(requestDto.mainAccountId());
 
 		//잔고 파악
-		if(!mainAccountService.checkBalanceAvailability(mainAccount, requestDto.money())){
+		if(!mainAccount.checkBalanceAvailability(requestDto.money())){
 			throw new BalanceUpdateException(ErrorCode.BALANCE_NOT_ENOUGH);
+
 		}
 
 		SavingAccount savingAccount = getSavingAccountWithXLock(requestDto.savingAccountId());
@@ -52,27 +54,5 @@ public class SavingAccountService {
 
 	private SavingAccount getSavingAccountWithXLock(long savingAccountId){
 		return savingAccountRepository.findByIdWithXLock(savingAccountId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_SAVING_ACCOUNT));
-	}
-
-	/**
-	 * 계좌 번호 생성
-	 * */
-	private String createAccountNumber(){
-		Random random = new Random();
-		int createNum = 0;
-		String ranNum = "";
-		String randomNum = "";
-
-		for (int i=0; i<7; i++) {
-			createNum = random.nextInt(9);
-			ranNum = Integer.toString(createNum);
-			randomNum += ranNum;
-		}
-		String bankNum = "3333";
-		String countAccountNum = String.format("%02d",counter);
-
-		counter++;
-		String accountNum = bankNum+"-"+countAccountNum+"-"+randomNum;
-		return accountNum;
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/service/SavingAccountService.java
+++ b/src/main/java/org/c4marathon/assignment/service/SavingAccountService.java
@@ -1,8 +1,13 @@
 package org.c4marathon.assignment.service;
 
 import java.util.Random;
+
+import org.c4marathon.assignment.common.exception.BalanceUpdateException;
+import org.c4marathon.assignment.common.exception.NotFoundException;
+import org.c4marathon.assignment.common.exception.enums.ErrorCode;
 import org.c4marathon.assignment.domain.MainAccount;
 import org.c4marathon.assignment.domain.SavingAccount;
+import org.c4marathon.assignment.dto.request.ChargeSavingAccountRequestDto;
 import org.c4marathon.assignment.dto.request.SavingAccountRequestDto;
 import org.c4marathon.assignment.repository.SavingAccountRepository;
 import org.springframework.stereotype.Service;
@@ -21,6 +26,32 @@ public class SavingAccountService {
 		MainAccount mainAccount = mainAccountService.getMainAccount(requestDto.mainAccountId());
 		SavingAccount savingAccount = new SavingAccount(mainAccount, createAccountNumber(), requestDto.balance(), requestDto.rate());
 		savingAccountRepository.save(savingAccount);
+	}
+
+	/**
+	 * 메인 계좌 => 적금 계좌로 돈 충전
+	 * [1] 메인 계좌 => 적금 계좌 방향으로 돈이 흐르니, MainAccount 먼저 Lock 획득
+	 * [2] 잔고 파악
+	 * [3] 적금 계좌 업데이트
+	 * [4] 메인 계좌 업데이트
+	 * */
+	@Transactional
+	public void chargeFromMainAccount(ChargeSavingAccountRequestDto requestDto){
+		MainAccount mainAccount = mainAccountService.getMainAccountWithXLock(requestDto.mainAccountId());
+
+		//잔고 파악
+		if(!mainAccountService.checkBalanceAvailability(mainAccount, requestDto.money())){
+			throw new BalanceUpdateException(ErrorCode.BALANCE_NOT_ENOUGH);
+		}
+
+		SavingAccount savingAccount = getSavingAccountWithXLock(requestDto.savingAccountId());
+		savingAccount.chargeMoney(requestDto.money());
+		savingAccountRepository.save(savingAccount);
+		mainAccountService.withdrawMoney(mainAccount, requestDto.money());
+	}
+
+	private SavingAccount getSavingAccountWithXLock(long savingAccountId){
+		return savingAccountRepository.findByIdWithXLock(savingAccountId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_SAVING_ACCOUNT));
 	}
 
 	/**

--- a/src/main/java/org/c4marathon/assignment/service/UserService.java
+++ b/src/main/java/org/c4marathon/assignment/service/UserService.java
@@ -1,0 +1,24 @@
+package org.c4marathon.assignment.service;
+
+import org.c4marathon.assignment.domain.MainAccount;
+import org.c4marathon.assignment.domain.User;
+import org.c4marathon.assignment.dto.request.SignUpRequestDto;
+import org.c4marathon.assignment.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+	private final UserRepository userRepository;
+	private final MainAccountService mainAccountService;
+
+	@Transactional
+	public void signUp(SignUpRequestDto requestDto){
+		User user = new User(requestDto.username());
+		userRepository.save(user);
+		mainAccountService.createMainAccount(user);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/service/UserService.java
+++ b/src/main/java/org/c4marathon/assignment/service/UserService.java
@@ -1,6 +1,5 @@
 package org.c4marathon.assignment.service;
 
-import org.c4marathon.assignment.domain.MainAccount;
 import org.c4marathon.assignment.domain.User;
 import org.c4marathon.assignment.dto.request.SignUpRequestDto;
 import org.c4marathon.assignment.repository.UserRepository;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,9 +15,9 @@ spring:
         format_sql: false
         use_sql_comments: false
         dialect: org.hibernate.dialect.MySQLDialect
-#  data:
-#    redis:
-#      host: ${REDIS_ID}
-#      port: 6379
-#      password: ${REDIS_PASSWORD}
-#      timeout: 2000
+  data:
+    redis:
+      host: ${REDIS_ID}
+      port: 6379
+      password: ${REDIS_PASSWORD}
+      timeout: 2000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,9 +9,15 @@ spring:
   jpa:
     show-sql: false
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: false
         use_sql_comments: false
         dialect: org.hibernate.dialect.MySQLDialect
+#  data:
+#    redis:
+#      host: ${REDIS_ID}
+#      port: 6379
+#      password: ${REDIS_PASSWORD}
+#      timeout: 2000


### PR DESCRIPTION
## DB ERD
<img width="400" alt="스크린샷 2025-01-28 오전 6 53 59" src="https://github.com/user-attachments/assets/bc761931-c3bc-42ab-8743-77e8c0a0817e" />

<br>

## Transaction Isolation Level
- Read Commited
    - 커밋된 데이터만 조회하는 Read Commited은 Dirty Read 발생 가능성을 막지만 Non-Repeatable Read, Phantom Read가 일어날 수 있습니다. 
    - Non-Repeatable Read는 일반적인 경우에는 크게 문제가 되지 않지만, 하나의 트랜잭션에서 동일한 데이터를 여러 번 읽고 변경하는 작업이 금전적인 처리와 연결되면 문제가 생길 수 있다는 것을 찾아보게 되었습니다.
    - 예를 들어 어떤 트랜잭션에서는 오늘 입금된 총 합을 계산하고 있는데, 다른 트랜잭션에서 계속해서 입금 내역을 커밋하는 상황이라고 하면, 같은 트랜잭션일지라도 조회할 때마다 입금된 내역이 달라지므로 문제가 생길 수 있는 것입니다.
- Repeatable Read
    - 한 트랜잭션 내에서 동일한 결과를 보장하지만, 새로운 레코드가 추가되는 경우에 부정합이 생길 수 있습니다.
    - Non-Repeatable Read 해결하고, Phantom Read가 일어날 수 있지만 Mysql에서는 거의 발생하지 않는다고 합니다.
    - Mysql 같은 경우에는 select ..for update의 목적으로 조회했을 경우 갭락 + 레코드락인 넥스트 키 락을 걸기 때문에, 해당 조건에 해당하는 insert문이 들어온다면 락 타임아웃이 발생하는 경우가 있습니다. 

1. [Repeatable Read] 적금계좌 생성시
메인 계좌를 조회한 결과를 토대로 적금계좌를 개설한다. 조회를 하면서 중간에 메인 계좌의 값이 변경되면 안되므로 한 트랜잭션 내에서 동일한 결과를 보장하는 Repeatable Read를 선택했습니다.  
- 범위 검색이 아니기 때문에 갭락이 아닌 PK에 의한 레코드 락이 걸릴것이라 생각했습니다.
- 따라서 락 타임아웃 발생 가능성이 낮다고 생각해서, Repeatable Read를 선택하게 되었습니다. 

2. [Repeatable Read] 메인계좌 충전 시
메인 계좌에 금액을 충전하는 API 입니다. 충전을 하면서 적금으로도 충전되는 경우가 동시에 발생할 수 도 있다고 생각했습니다.따라서 정합성이 중요하다고 판단했습니다. 값이 충돌이 일어나면 안된다고 생각해서 Repeatable Read + 쓰기락을 구현해서 반영하는 로직을 구현했습니다. 

4.  [Repeatable Read] 적금계좌 충전 시
메인 계좌에 있는 금액과 내가 적금계좌로 충전하고자 하는 금액을 계산해서 충전해야하기 때문에, 메인계좌와 적금계좌 각각에 Repeatable Read + 쓰기락을 사용해서 구현했습니다. 이로 인해 락 타임아웃이 발생할 가능성이 더 높아져서 어떻게 풀어나갈지 고민중에 있습니다. 

> ❓적금계좌 충전시 메인계좌와 적금계좌 각각에 쓰기락을 사용했는데, 이 부분이 굉장히 성능을 저하시키는 부분이라고 생각하는데, 어떻게 하면 트랜잭션 사이 시간을 줄이거나 효율적이게 할 수 있을 지 궁금합니다.
> ❓Repeatable Read보다 정합성이 떨어지는 Read Commited는 어떠한 상황이 주어졌을 때 사용할 수 있을지 궁금합니다. 

<br>

## Daily Limit
DB의 부하를 줄이기 위해 메모리를 사용해서 충전 한도를 관리하는것이 적합하다고 생각했습니다.
- 메모리를 사용하지 않을 경우, 한도를 확인하고 갱신할 때 마다 DB Lock이 걸리게 됩니다. Mysql 같은 경우 인덱스락이 걸리기 때문에 고려해야할 것이 많습니다. 또한 트래픽이 많을 경우에는 대기로 인한 장애가 발생할 수도 있니다.
- 메모리 중, Redis를 사용하지 않는 이유 : 현재 개발 서버는 단일 서버고 분산 환경이 아니기 때문 (실제 개발에서는 여러 이유로.. Redis를 사용하는 것이 더 적합할 것이라고 생각합니다.)

위와 같은 이유 Spring에서 제공하는 로컬 캐시를 사용하기로 결정했습다. 디폴트로 있는 ConcurrentMapCache를 사용하려고 했습니다…. ✨But Local Cache 구현이 너무 어려워서 현재 Redis로 구현했습니다.
1.  [메인계좌 충전 시] 다수의 유저가 충전(송금?)할 수 있기 때문에, Redis로 동시성 이슈를 해결해야하는데 분산락까지 사용해서 잠금 처리를 하는 것이 적당한가 고민중에 있습니다. 
3. [12시 마다 일일 한도 리셋] 실제 은행의 자정 때 쯤 은행 점검시간에서 아이디어를 얻어, 24시가 되었을때 10동안 레디스에 reset key를 만들어 자체 락을 구현했습니다. 24시가 되었을 때 기존의 일일 한도와 관련된 모든 데이터를 삭제합니다.

> ❓좀 더 고민해보자면 Redis 장애시를 고려한 Master-slave 모드로 Redis Server 구축이 필요할것이라 생각됩니다.
        원래는 Local Cache + Redis(복구용)으로 사용하려고 했으나 실패


<br>

### Test Code는 Not Yet... 💔 
### 좀 더 수정하고 개선한 후에 스터디 전에 태그 하겠습니다!