### PR TITLE
Feature/zzambas step1

### DIFF
--- a/src/main/java/org/c4marathon/assignment/application/AccountService.java
+++ b/src/main/java/org/c4marathon/assignment/application/AccountService.java
@@ -1,0 +1,127 @@
+package org.c4marathon.assignment.application;
+
+import java.time.LocalDateTime;
+
+import org.c4marathon.assignment.domain.Account;
+import org.c4marathon.assignment.domain.AccountRepository;
+import org.c4marathon.assignment.domain.AccountType;
+import org.c4marathon.assignment.domain.User;
+import org.c4marathon.assignment.domain.UserRepository;
+import org.c4marathon.assignment.domain.dto.response.CreatedAccountInfo;
+import org.c4marathon.assignment.domain.dto.response.TransferResult;
+import org.c4marathon.assignment.domain.dto.response.WithdrawResult;
+import org.c4marathon.assignment.global.AccountUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AccountService {
+	private final AccountRepository accountRepository;
+	private final UserRepository userRepository;
+
+	// 단순 출금
+	@Transactional(isolation = Isolation.READ_COMMITTED)
+	public WithdrawResult withdraw(String accountNumber, long money) {
+		LocalDateTime withdrawTime = LocalDateTime.now();
+
+		updateWithdrawLimit(accountNumber, money, withdrawTime);
+		updateBalance(accountNumber, -money);
+
+		return new WithdrawResult(money);
+	}
+
+	// 거래
+	@Transactional(isolation = Isolation.READ_COMMITTED)
+	public TransferResult transfer(String senderAccountNumber, String receiverAccountNumber, long money) {
+		LocalDateTime transferTime = LocalDateTime.now();
+
+		validateSender(senderAccountNumber, receiverAccountNumber);
+		updateWithdrawLimit(senderAccountNumber, money, transferTime);
+
+		transferWithoutDeadlock(senderAccountNumber, receiverAccountNumber, money);
+
+		return new TransferResult(senderAccountNumber, receiverAccountNumber, money);
+	}
+
+	/**
+	 *
+	 * @param userId
+	 * @param accountType
+	 * @return
+	 *
+	 * 계좌 생성. accountType은 생성 계좌가 적금 계좌인지 입출금 계좌인지를 판단.
+	 */
+	@Transactional(isolation = Isolation.READ_COMMITTED)
+	public CreatedAccountInfo create(long userId, AccountType accountType) {
+		userRepository.findById(userId).orElseThrow(() -> new RuntimeException("User not found."));
+
+		String accountNumber = AccountUtils.getAccountNumber();
+
+		Account savedAccount = accountRepository.save(
+			Account.builder().userId(userId).accountType(accountType).accountNumber(accountNumber).build());
+
+		return new CreatedAccountInfo(savedAccount.getAccountNumber(), savedAccount.getCreatedAt(),
+			savedAccount.getAccountType(), savedAccount.getBalance(), savedAccount.isMain());
+	}
+
+	private void updateBalance(String accountNumber, long money) {
+		int updatedRow = accountRepository.addBalance(money, accountNumber);
+
+		if (updatedRow == 0)
+			throw new RuntimeException("Failed to update balance.");
+	}
+
+	/**
+	 * @param senderAccountNumber
+	 * @param receiverAccountNumber
+	 *
+	 * 적금 계좌는 송신 계좌가 메인 계좌여야 하기 때문에 그 조건을 판단하는 역할을 하는 메서드.
+	 */
+	private void validateSender(String senderAccountNumber, String receiverAccountNumber) {
+		Account receiver = accountRepository.findByAccountNumber(receiverAccountNumber)
+			.orElseThrow(() -> new RuntimeException("Account not found."));
+
+		if (receiver.getAccountType() != AccountType.INSTALLATION)
+			return;
+
+		Account mainAccount = accountRepository.findMainAccount(receiver.getUserId())
+			.orElseThrow(() -> new RuntimeException("Account not found."));
+
+		if (!mainAccount.getAccountNumber().equals(senderAccountNumber))
+			throw new RuntimeException("적금 계좌는 본인의 메인 계좌에서만 거래 가능합니다.");
+	}
+
+	// 한도 확인
+	private void updateWithdrawLimit(String accountNumber, long money, LocalDateTime withdrawTime) {
+		Account account = accountRepository.findByAccountNumber(accountNumber)
+			.orElseThrow(() -> new RuntimeException("Account not found."));
+		User user = userRepository.findById(account.getUserId())
+			.orElseThrow(() -> new RuntimeException("User not found."));
+
+		LocalDateTime lastWithdrawDate = user.getLastWithdrawDate();
+
+		if (lastWithdrawDate.toLocalDate().isBefore(withdrawTime.toLocalDate())) {
+			userRepository.initializeWithdrawLimit(user.getId());
+		}
+
+		userRepository.withdraw(user.getId(), money, withdrawTime);
+	}
+
+	// 순환 대기 문제 해결을 위해 계좌 번호 사전 순으로 트랜잭션 처리
+	private void transferWithoutDeadlock(String senderAccountNumber, String receiverAccountNumber, long money) {
+		if (senderAccountNumber.compareTo(receiverAccountNumber) < 0) {
+			updateBalance(senderAccountNumber, -money);
+			updateBalance(receiverAccountNumber, money);
+		}
+		else {
+			updateBalance(receiverAccountNumber, money);
+			updateBalance(senderAccountNumber, -money);
+		}
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/application/UserService.java
+++ b/src/main/java/org/c4marathon/assignment/application/UserService.java
@@ -1,0 +1,28 @@
+package org.c4marathon.assignment.application;
+
+import org.c4marathon.assignment.domain.Account;
+import org.c4marathon.assignment.domain.AccountRepository;
+import org.c4marathon.assignment.domain.User;
+import org.c4marathon.assignment.domain.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+	private final UserRepository userRepository;
+	private final AccountRepository accountRepository;
+
+	@Transactional
+	public boolean register(String email) {
+		User createdUser = User.builder().email(email).build();
+		userRepository.save(createdUser);
+
+		Account account = Account.builder().isMain(true).userId(createdUser.getId()).build();
+		accountRepository.save(account);
+
+		return true;
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/controller/AccountController.java
+++ b/src/main/java/org/c4marathon/assignment/controller/AccountController.java
@@ -1,0 +1,41 @@
+package org.c4marathon.assignment.controller;
+
+import org.c4marathon.assignment.application.AccountService;
+import org.c4marathon.assignment.domain.AccountType;
+import org.c4marathon.assignment.domain.dto.request.TransferRequest;
+import org.c4marathon.assignment.domain.dto.request.WithdrawRequest;
+import org.c4marathon.assignment.domain.dto.response.CreatedAccountInfo;
+import org.c4marathon.assignment.domain.dto.response.TransferResult;
+import org.c4marathon.assignment.domain.dto.response.WithdrawResult;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/account")
+@RequiredArgsConstructor
+public class AccountController {
+	private final AccountService accountService;
+
+	@PostMapping("/create")
+	public ResponseEntity<CreatedAccountInfo> create(@RequestParam long userId, @RequestParam AccountType accountType) {
+		return ResponseEntity.status(HttpStatus.CREATED).body(accountService.create(userId, accountType));
+	}
+
+	@PostMapping("/withdraw")
+	public ResponseEntity<WithdrawResult> withdraw(@RequestBody WithdrawRequest request) {
+		return ResponseEntity.ok(accountService.withdraw(request.accountNumber(), request.money()));
+	}
+
+	@PostMapping("/transfer")
+	public ResponseEntity<TransferResult> transfer(@RequestBody TransferRequest request) {
+		return ResponseEntity.ok(
+			accountService.transfer(request.senderAccountNumber(), request.receiverAccountNumber(), request.money()));
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/controller/UserController.java
+++ b/src/main/java/org/c4marathon/assignment/controller/UserController.java
@@ -1,0 +1,23 @@
+package org.c4marathon.assignment.controller;
+
+import org.c4marathon.assignment.application.UserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/user")
+@RequiredArgsConstructor
+public class UserController {
+	private final UserService userService;
+
+	@PostMapping("/register")
+	public ResponseEntity<Boolean> register(@RequestParam String email) {
+		return ResponseEntity.status(HttpStatus.CREATED).body(userService.register(email));
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/Account.java
+++ b/src/main/java/org/c4marathon/assignment/domain/Account.java
@@ -1,0 +1,60 @@
+package org.c4marathon.assignment.domain;
+
+import java.time.LocalDateTime;
+
+import org.c4marathon.assignment.global.AccountUtils;
+import org.hibernate.annotations.ColumnDefault;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+@Entity
+@Table(name = "account")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Account extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id", nullable = false)
+	private Long id;
+
+	@ColumnDefault("0")
+	@Column(name = "balance", nullable = false)
+	private long balance;
+
+	@Column(name = "account_number", nullable = false, unique = true, length = 50)
+	private String accountNumber;
+
+	@Column(name = "is_main", nullable = false)
+	private boolean isMain;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "account_type", nullable = false, length = 30)
+	private AccountType accountType;
+
+	@Column(name = "user_id", nullable = false)
+	private long userId;
+
+	@Builder
+	private Account(long balance, String accountNumber, boolean isMain, AccountType accountType, Long userId,
+		LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+		super(createdAt, updatedAt, deletedAt);
+		this.balance = balance;
+		this.accountNumber = accountNumber != null ? accountNumber : AccountUtils.getAccountNumber();
+		this.isMain = isMain;
+		this.accountType = accountType != null ? accountType : AccountType.CHECKING;
+		this.userId = userId;
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/AccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/AccountRepository.java
@@ -1,0 +1,19 @@
+package org.c4marathon.assignment.domain;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface AccountRepository extends JpaRepository<Account, Long> {
+	@Modifying
+	@Query("UPDATE Account a SET a.balance = a.balance + :money WHERE a.accountNumber = :accountNumber AND a.balance + :money >= 0")
+	int addBalance(@Param("money") long money, @Param("accountNumber") String accountNumber);
+
+	Optional<Account> findByAccountNumber(String accountNumber);
+
+	@Query("SELECT a FROM Account a WHERE a.userId = :userId AND a.isMain = true")
+	Optional<Account> findMainAccount(Long userId);
+}

--- a/src/main/java/org/c4marathon/assignment/domain/AccountType.java
+++ b/src/main/java/org/c4marathon/assignment/domain/AccountType.java
@@ -1,0 +1,6 @@
+package org.c4marathon.assignment.domain;
+
+public enum AccountType {
+	CHECKING, // 입출금(일반)
+	INSTALLATION // 적금
+}

--- a/src/main/java/org/c4marathon/assignment/domain/BaseEntity.java
+++ b/src/main/java/org/c4marathon/assignment/domain/BaseEntity.java
@@ -1,0 +1,30 @@
+package org.c4marathon.assignment.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@MappedSuperclass
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class BaseEntity {
+
+	@Column(name = "created_at", nullable = false, columnDefinition = "datetime")
+	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at", nullable = false, columnDefinition = "datetime")
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at", columnDefinition = "datetime")
+	private LocalDateTime deletedAt;
+
+	protected BaseEntity(LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+		this.createdAt = createdAt != null ? createdAt : LocalDateTime.now();
+		this.updatedAt = updatedAt != null ? updatedAt : this.createdAt;
+		this.deletedAt = deletedAt;
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/User.java
+++ b/src/main/java/org/c4marathon/assignment/domain/User.java
@@ -2,8 +2,6 @@ package org.c4marathon.assignment.domain;
 
 import java.time.LocalDateTime;
 
-import org.hibernate.annotations.ColumnDefault;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/org/c4marathon/assignment/domain/User.java
+++ b/src/main/java/org/c4marathon/assignment/domain/User.java
@@ -1,0 +1,51 @@
+package org.c4marathon.assignment.domain;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.ColumnDefault;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "user")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+	static final long DEFAULT_WITHDRAW_LIMIT = 3_000_000L;
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id", nullable = false)
+	private Long id;
+
+	@Column(name = "email", unique = true, nullable = false, length = 50)
+	private String email;
+
+	@Column(name = "day_withdraw_limit", nullable = false)
+	private long dayWithdrawLimit;
+
+	@Column(name = "day_withdraw", nullable = false)
+	private long dayWithdraw;
+
+	@Column(name = "last_withdraw_date")
+	private LocalDateTime lastWithdrawDate;
+
+	@Builder
+	private User(LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt,
+		String email, Long dayWithdrawLimit, long dayWithdraw, LocalDateTime lastWithdrawDate) {
+		super(createdAt, updatedAt, deletedAt);
+		this.email = email;
+		this.dayWithdrawLimit = dayWithdrawLimit != null ? dayWithdrawLimit : DEFAULT_WITHDRAW_LIMIT;
+		this.dayWithdraw = dayWithdraw;
+		this.lastWithdrawDate = lastWithdrawDate != null ? lastWithdrawDate : LocalDateTime.now();
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/UserRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/UserRepository.java
@@ -1,0 +1,18 @@
+package org.c4marathon.assignment.domain;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+	@Modifying
+	@Query("UPDATE User u SET u.dayWithdrawLimit = 0 WHERE u.id = :id")
+	int initializeWithdrawLimit(Long id);
+
+	@Modifying
+	@Query("UPDATE User u SET u.dayWithdraw = u.dayWithdraw + :money, u.lastWithdrawDate = :withdrawTime WHERE u.id = :id AND u.dayWithdraw + :money <= u.dayWithdrawLimit")
+	int withdraw(Long id, long money, LocalDateTime withdrawTime);
+}

--- a/src/main/java/org/c4marathon/assignment/domain/dto/request/TransferRequest.java
+++ b/src/main/java/org/c4marathon/assignment/domain/dto/request/TransferRequest.java
@@ -1,0 +1,4 @@
+package org.c4marathon.assignment.domain.dto.request;
+
+public record TransferRequest(String senderAccountNumber, String receiverAccountNumber, long money) {
+}

--- a/src/main/java/org/c4marathon/assignment/domain/dto/request/WithdrawRequest.java
+++ b/src/main/java/org/c4marathon/assignment/domain/dto/request/WithdrawRequest.java
@@ -1,0 +1,4 @@
+package org.c4marathon.assignment.domain.dto.request;
+
+public record WithdrawRequest(String accountNumber, long money) {
+}

--- a/src/main/java/org/c4marathon/assignment/domain/dto/response/CreatedAccountInfo.java
+++ b/src/main/java/org/c4marathon/assignment/domain/dto/response/CreatedAccountInfo.java
@@ -1,0 +1,9 @@
+package org.c4marathon.assignment.domain.dto.response;
+
+import java.time.LocalDateTime;
+
+import org.c4marathon.assignment.domain.AccountType;
+
+public record CreatedAccountInfo(String accountNumber, LocalDateTime createdAt, AccountType accountType, long balance,
+								 boolean isMain) {
+}

--- a/src/main/java/org/c4marathon/assignment/domain/dto/response/TransferResult.java
+++ b/src/main/java/org/c4marathon/assignment/domain/dto/response/TransferResult.java
@@ -1,0 +1,4 @@
+package org.c4marathon.assignment.domain.dto.response;
+
+public record TransferResult(String senderAccountNumber, String receiverAccountNumber, long money) {
+}

--- a/src/main/java/org/c4marathon/assignment/domain/dto/response/WithdrawResult.java
+++ b/src/main/java/org/c4marathon/assignment/domain/dto/response/WithdrawResult.java
@@ -1,0 +1,4 @@
+package org.c4marathon.assignment.domain.dto.response;
+
+public record WithdrawResult(long withdrawValue) {
+}

--- a/src/main/java/org/c4marathon/assignment/global/AccountUtils.java
+++ b/src/main/java/org/c4marathon/assignment/global/AccountUtils.java
@@ -1,0 +1,15 @@
+package org.c4marathon.assignment.global;
+
+import java.util.Random;
+import java.util.stream.IntStream;
+
+public class AccountUtils {
+	static final Random RANDOM = new Random();
+	static final int LIMIT = 13;
+
+	public static String getAccountNumber() {
+		StringBuilder accountNumber = new StringBuilder();
+		IntStream.range(0, LIMIT).forEach(i -> accountNumber.append((char)('0' + RANDOM.nextInt(10))));
+		return accountNumber.toString();
+	}
+}


### PR DESCRIPTION
# 아직 테스트 코드 작성을 하지 못했습니다.

## 전체적 구성
![image](https://github.com/user-attachments/assets/4a423d44-167a-4e20-af8e-1e67e2a93c94)

* DB에 `User`, `Account` 테이블을 생성했고 각각은 사용자, 계좌 정보를 뜻합니다. 사용자 정보는 간단히 구현했고 따로 인증을 하지는 않습니다.
* `Account` 테이블에는 적금 계좌, 입출금 계좌 전부 들어갈 수 있고 `account_type` 컬럼으로 이를 판별합니다. (CHECKING: 입출금, INSTALLATION: 적금). 계좌번호에 unique 인덱스를 설정했습니다.
* 인당 출전 한도는 `User` 테이블에서 관리합니다. 관련 컬럼은 `day_withdraw_limit` 입니다. 이에 따라 해당 사용자의 일일 출전 금액과 마지막 출전 일시를 저장할 필요가 있다 생각해서 `day_withdraw` 컬럼과 `last_withdraw_date` 컬럼을 추가했습니다.
* 적금 계좌는 자유 적금 계좌로 가정했습니다. 이에 따라 따로 특정 일시마다 돈이 빠져나가는 시스템은 아닙니다.

## 구현사항
각 구현 사항에 대해 제 구현은 다음과 같습니다.
* 각 사용자가 여러 계좌를 생성할 수 있게 만들어야 합니다.
  * 계좌 생성 API로 수행 가능합니다. 사용자 Id 값과 입출금/적금 계좌 종류를 인자로 받아 생성할 수 있습니다. (아직 메인 계좌 변경 API는 없음)
* 메인 계좌는 외부 계좌에서 돈을 가져오는 기능이 주 기능이므로, 금액 추가가 가능합니다. 1일 출전 한도는 3,000,000원 입니다.
  * 출전 한도는 `User` 테이블에서 관리하며 거래(출금, 송금) 시, 그 출금이 한도를 초과하는지 먼저 검사한 후, 처리가 됩니다.
* 적금 계좌는 메인 계좌에서 돈을 인출할 수 있으며, 메인 계좌의 돈이 없으면 인출할 수 없습니다.
  * 송금 시, 송금하는 계좌가 적금 계좌에 돈을 넣을 수 있는 계좌인지 판별한 후, 가능하면 거래합니다. 
## 프로그래밍 요구사항
* 적금 계좌 - 메인 계좌 간 트랜잭션
  * Read Uncommitted는 트랜잭션 간 간섭이 존재할 수 있기에 제외, Serializable은 MySQL에서 단순 조회문도 락을 걸기에 제외했습니다. Repeatable Read는 DML 처리를 할 때, 확인하는 모든 레코드에 X락을 겁니다. 그러나 Read Committed는 WHERE 절 처리에 속하지 않는 레코드는 락을 바로 풀게 됩니다. 데드락 가능성을 줄여줄 수 있다고 생각하였고, SELECT 시에도 Repeatable Read는 스냅샷을 가져오는 반면, Read Committed는 최신 커밋을 반영한 데이터를 스냅샷으로 갱신하고 가져옵니다. 최신 데이터가 중요한 시스템이라 생각하여 Read Committed를 선택했습니다.
  * A 계좌, B 계좌가 있을 때, A->B, B->A로 동시 송금이 발생하는 경우, 상황에 따라 두 계좌가 모두 X락이 걸려 데드락이 발생하는 상황을 발견했습니다. 이에 따라 계좌 번호 사전순 처리를 통해 데드락을 해결했습니다.
* 인당 한도 관리
  * 컬럼으로 일단 관리를 하는데 일마다 초기화 하는 부분을 생각해 보았습니다. 테이블을 초기화하는 것은 느리고, 캐시로 두자니 트랜잭션 실패 처리가 힘들 것 같았습니다. 이에 따라 컬럼으로 따로 두고 지연 초기화하기로 했습니다. `User` 테이블 내 `last_withdraw_date`를 참고하고 거래 일시와 비교해 하루가 지났으면 해당 테이블 내 `day_withdraw`를 0으로 초기화합니다. 그렇지 않으면 그대로 둡니다. 

## 문제점
아직 다음 문제가 존재합니다.
* 락으로 인한 지연
  * A 계좌와 B 계좌가 있을 때, A->B 거래(ㄱ) 도중 다른 C->A 거래가 일어나거나 B->C 거래가 일어날 때, (ㄱ)의 처리가 느려지면 락을 대기하느라 같이 느려지는 현상이 있습니다. 해결책을 찾는 중입니다.