### PR TITLE
Feature/zzambas step2

### DIFF
--- a/src/main/java/org/c4marathon/assignment/AssignmentApplication.java
+++ b/src/main/java/org/c4marathon/assignment/AssignmentApplication.java
@@ -2,8 +2,10 @@ package org.c4marathon.assignment;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class AssignmentApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/c4marathon/assignment/application/AccountService.java
+++ b/src/main/java/org/c4marathon/assignment/application/AccountService.java
@@ -1,0 +1,127 @@
+package org.c4marathon.assignment.application;
+
+import java.time.LocalDateTime;
+
+import org.c4marathon.assignment.domain.Account;
+import org.c4marathon.assignment.domain.AccountRepository;
+import org.c4marathon.assignment.domain.AccountType;
+import org.c4marathon.assignment.domain.User;
+import org.c4marathon.assignment.domain.UserRepository;
+import org.c4marathon.assignment.domain.dto.response.CreatedAccountInfo;
+import org.c4marathon.assignment.domain.dto.response.TransferResult;
+import org.c4marathon.assignment.domain.dto.response.WithdrawResult;
+import org.c4marathon.assignment.global.AccountUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AccountService {
+	private final AccountRepository accountRepository;
+	private final UserRepository userRepository;
+
+	// 단순 출금
+	@Transactional(isolation = Isolation.READ_COMMITTED)
+	public WithdrawResult withdraw(String accountNumber, long money) {
+		LocalDateTime withdrawTime = LocalDateTime.now();
+
+		updateWithdrawLimit(accountNumber, money, withdrawTime);
+		updateBalance(accountNumber, -money);
+
+		return new WithdrawResult(money);
+	}
+
+	// 거래
+	@Transactional(isolation = Isolation.READ_COMMITTED)
+	public TransferResult transfer(String senderAccountNumber, String receiverAccountNumber, long money) {
+		LocalDateTime transferTime = LocalDateTime.now();
+
+		validateSender(senderAccountNumber, receiverAccountNumber);
+		updateWithdrawLimit(senderAccountNumber, money, transferTime);
+
+		transferWithoutDeadlock(senderAccountNumber, receiverAccountNumber, money);
+
+		return new TransferResult(senderAccountNumber, receiverAccountNumber, money);
+	}
+
+	/**
+	 *
+	 * @param userId
+	 * @param accountType
+	 * @return
+	 *
+	 * 계좌 생성. accountType은 생성 계좌가 적금 계좌인지 입출금 계좌인지를 판단.
+	 */
+	@Transactional(isolation = Isolation.READ_COMMITTED)
+	public CreatedAccountInfo create(long userId, AccountType accountType) {
+		userRepository.findById(userId).orElseThrow(() -> new RuntimeException("User not found."));
+
+		String accountNumber = AccountUtils.getAccountNumber();
+
+		Account savedAccount = accountRepository.save(
+			Account.builder().userId(userId).accountType(accountType).accountNumber(accountNumber).build());
+
+		return new CreatedAccountInfo(savedAccount.getAccountNumber(), savedAccount.getCreatedAt(),
+			savedAccount.getAccountType(), savedAccount.getBalance(), savedAccount.isMain());
+	}
+
+	private void updateBalance(String accountNumber, long money) {
+		int updatedRow = accountRepository.addBalance(money, accountNumber);
+
+		if (updatedRow == 0)
+			throw new RuntimeException("Failed to update balance.");
+	}
+
+	/**
+	 * @param senderAccountNumber
+	 * @param receiverAccountNumber
+	 *
+	 * 적금 계좌는 송신 계좌가 메인 계좌여야 하기 때문에 그 조건을 판단하는 역할을 하는 메서드.
+	 */
+	private void validateSender(String senderAccountNumber, String receiverAccountNumber) {
+		Account receiver = accountRepository.findByAccountNumber(receiverAccountNumber)
+			.orElseThrow(() -> new RuntimeException("Account not found."));
+
+		if (receiver.getAccountType() != AccountType.INSTALLATION)
+			return;
+
+		Account mainAccount = accountRepository.findMainAccount(receiver.getUserId())
+			.orElseThrow(() -> new RuntimeException("Account not found."));
+
+		if (!mainAccount.getAccountNumber().equals(senderAccountNumber))
+			throw new RuntimeException("적금 계좌는 본인의 메인 계좌에서만 거래 가능합니다.");
+	}
+
+	// 한도 확인
+	private void updateWithdrawLimit(String accountNumber, long money, LocalDateTime withdrawTime) {
+		Account account = accountRepository.findByAccountNumber(accountNumber)
+			.orElseThrow(() -> new RuntimeException("Account not found."));
+		User user = userRepository.findById(account.getUserId())
+			.orElseThrow(() -> new RuntimeException("User not found."));
+
+		LocalDateTime lastWithdrawDate = user.getLastWithdrawDate();
+
+		if (lastWithdrawDate.toLocalDate().isBefore(withdrawTime.toLocalDate())) {
+			userRepository.initializeWithdrawLimit(user.getId());
+		}
+
+		userRepository.withdraw(user.getId(), money, withdrawTime);
+	}
+
+	// 순환 대기 문제 해결을 위해 계좌 번호 사전 순으로 트랜잭션 처리
+	private void transferWithoutDeadlock(String senderAccountNumber, String receiverAccountNumber, long money) {
+		if (senderAccountNumber.compareTo(receiverAccountNumber) < 0) {
+			updateBalance(senderAccountNumber, -money);
+			updateBalance(receiverAccountNumber, money);
+		}
+		else {
+			updateBalance(receiverAccountNumber, money);
+			updateBalance(senderAccountNumber, -money);
+		}
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/application/AccountService.java
+++ b/src/main/java/org/c4marathon/assignment/application/AccountService.java
@@ -1,19 +1,16 @@
 package org.c4marathon.assignment.application;
 
-import java.time.LocalDateTime;
+import static org.c4marathon.assignment.global.AccountUtils.*;
+import static org.c4marathon.assignment.global.CommonUtils.*;
 
 import org.c4marathon.assignment.domain.Account;
 import org.c4marathon.assignment.domain.AccountRepository;
 import org.c4marathon.assignment.domain.AccountType;
-import org.c4marathon.assignment.domain.User;
 import org.c4marathon.assignment.domain.UserRepository;
 import org.c4marathon.assignment.domain.dto.response.CreatedAccountInfo;
 import org.c4marathon.assignment.domain.dto.response.TransferResult;
 import org.c4marathon.assignment.domain.dto.response.WithdrawResult;
-import org.c4marathon.assignment.global.AccountUtils;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Isolation;
-import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,29 +19,33 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class AccountService {
+	static final long CEILING_POINT = 10_000L;
+
+	private final AccountTransactionService accountTxService;
 	private final AccountRepository accountRepository;
 	private final UserRepository userRepository;
 
 	// 단순 출금
-	@Transactional(isolation = Isolation.READ_COMMITTED)
 	public WithdrawResult withdraw(String accountNumber, long money) {
-		LocalDateTime withdrawTime = LocalDateTime.now();
-
-		updateWithdrawLimit(accountNumber, money, withdrawTime);
-		updateBalance(accountNumber, -money);
+		accountTxService.updateBalance(accountNumber, -money);
 
 		return new WithdrawResult(money);
 	}
 
-	// 거래
-	@Transactional(isolation = Isolation.READ_COMMITTED)
+	/**
+	 * 송금 메서드. 송금 유효 판단 후 계좌에 송금 금액만큼 충전. 마지막으로 송금.
+	 * @param senderAccountNumber
+	 * @param receiverAccountNumber
+	 * @param money
+	 * @return
+	 */
 	public TransferResult transfer(String senderAccountNumber, String receiverAccountNumber, long money) {
-		LocalDateTime transferTime = LocalDateTime.now();
-
 		validateSender(senderAccountNumber, receiverAccountNumber);
-		updateWithdrawLimit(senderAccountNumber, money, transferTime);
-
-		transferWithoutDeadlock(senderAccountNumber, receiverAccountNumber, money);
+		long diff = computeBalanceDiff(senderAccountNumber, money);
+		if (diff < 0) {
+			accountTxService.updateBalance(senderAccountNumber, getCeil(-diff, CEILING_POINT));
+		}
+		accountTxService.wireTransfer(senderAccountNumber, receiverAccountNumber, money);
 
 		return new TransferResult(senderAccountNumber, receiverAccountNumber, money);
 	}
@@ -57,31 +58,23 @@ public class AccountService {
 	 *
 	 * 계좌 생성. accountType은 생성 계좌가 적금 계좌인지 입출금 계좌인지를 판단.
 	 */
-	@Transactional(isolation = Isolation.READ_COMMITTED)
 	public CreatedAccountInfo create(long userId, AccountType accountType) {
+		String accountNumber = getAccountNumber();
+
 		userRepository.findById(userId).orElseThrow(() -> new RuntimeException("User not found."));
 
-		String accountNumber = AccountUtils.getAccountNumber();
-
-		Account savedAccount = accountRepository.save(
-			Account.builder().userId(userId).accountType(accountType).accountNumber(accountNumber).build());
+		Account newAccount = Account.builder().userId(userId).accountType(accountType).accountNumber(accountNumber).build();
+		Account savedAccount = accountRepository.save(newAccount);
 
 		return new CreatedAccountInfo(savedAccount.getAccountNumber(), savedAccount.getCreatedAt(),
 			savedAccount.getAccountType(), savedAccount.getBalance(), savedAccount.isMain());
-	}
-
-	private void updateBalance(String accountNumber, long money) {
-		int updatedRow = accountRepository.addBalance(money, accountNumber);
-
-		if (updatedRow == 0)
-			throw new RuntimeException("Failed to update balance.");
 	}
 
 	/**
 	 * @param senderAccountNumber
 	 * @param receiverAccountNumber
 	 *
-	 * 적금 계좌는 송신 계좌가 메인 계좌여야 하기 때문에 그 조건을 판단하는 역할을 하는 메서드.
+	 * 적금 계좌는 송신 계좌가 메인 계좌여야 하기 때문에 그 조건을 판단하는 메서드.
 	 */
 	private void validateSender(String senderAccountNumber, String receiverAccountNumber) {
 		Account receiver = accountRepository.findByAccountNumber(receiverAccountNumber)
@@ -97,31 +90,17 @@ public class AccountService {
 			throw new RuntimeException("적금 계좌는 본인의 메인 계좌에서만 거래 가능합니다.");
 	}
 
-	// 한도 확인
-	private void updateWithdrawLimit(String accountNumber, long money, LocalDateTime withdrawTime) {
-		Account account = accountRepository.findByAccountNumber(accountNumber)
+	/**
+	 * @param senderAccountNumber
+	 * @param money
+	 * @return
+	 *
+	 * 송금 금액과 계좌 내 잔액이 얼마나 차이나는지 계산하는 메서드
+	 */
+	private long computeBalanceDiff(String senderAccountNumber, long money) {
+		Account account = accountRepository.findByAccountNumber(senderAccountNumber)
 			.orElseThrow(() -> new RuntimeException("Account not found."));
-		User user = userRepository.findById(account.getUserId())
-			.orElseThrow(() -> new RuntimeException("User not found."));
 
-		LocalDateTime lastWithdrawDate = user.getLastWithdrawDate();
-
-		if (lastWithdrawDate.toLocalDate().isBefore(withdrawTime.toLocalDate())) {
-			userRepository.initializeWithdrawLimit(user.getId());
-		}
-
-		userRepository.withdraw(user.getId(), money, withdrawTime);
-	}
-
-	// 순환 대기 문제 해결을 위해 계좌 번호 사전 순으로 트랜잭션 처리
-	private void transferWithoutDeadlock(String senderAccountNumber, String receiverAccountNumber, long money) {
-		if (senderAccountNumber.compareTo(receiverAccountNumber) < 0) {
-			updateBalance(senderAccountNumber, -money);
-			updateBalance(receiverAccountNumber, money);
-		}
-		else {
-			updateBalance(receiverAccountNumber, money);
-			updateBalance(senderAccountNumber, -money);
-		}
+		return account.getBalance() - money;
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/application/AccountTransactionService.java
+++ b/src/main/java/org/c4marathon/assignment/application/AccountTransactionService.java
@@ -1,0 +1,56 @@
+package org.c4marathon.assignment.application;
+
+import org.c4marathon.assignment.domain.Account;
+import org.c4marathon.assignment.domain.AccountRepository;
+import org.c4marathon.assignment.domain.UserRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AccountTransactionService {
+	private final AccountRepository accountRepository;
+	private final UserRepository userRepository;
+
+	@Transactional(isolation = Isolation.READ_COMMITTED)
+	public void updateBalance(String accountNumber, long money) {
+		if (money > 0) {
+			updateUser(accountNumber, money);
+		}
+
+		updateAccount(accountNumber, money);
+	}
+
+	// 순환 대기 문제 해결을 위해 계좌 번호 사전 순으로 트랜잭션 처리
+	@Transactional(isolation = Isolation.READ_COMMITTED)
+	public void wireTransfer(String senderAccountNumber, String receiverAccountNumber, long money) {
+		if (senderAccountNumber.compareTo(receiverAccountNumber) < 0) {
+			updateBalance(senderAccountNumber, -money);
+			updateBalance(receiverAccountNumber, money);
+		}
+		else {
+			updateBalance(receiverAccountNumber, money);
+			updateBalance(senderAccountNumber, -money);
+		}
+	}
+
+	private void updateUser(String accountNumber, long money) {
+		Account account = accountRepository.findByAccountNumber(accountNumber)
+			.orElseThrow(() -> new RuntimeException("Account not found"));
+
+		int updatedRow = userRepository.charge(account.getUserId(), money);
+
+		if (updatedRow == 0)
+			throw new RuntimeException("Account not charged");
+	}
+
+	private void updateAccount(String accountNumber, long money) {
+		int updatedRow = accountRepository.updateBalance(accountNumber, money);
+
+		if (updatedRow == 0)
+			throw new RuntimeException("Failed to update balance.");
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/application/ScheduledService.java
+++ b/src/main/java/org/c4marathon/assignment/application/ScheduledService.java
@@ -1,0 +1,33 @@
+package org.c4marathon.assignment.application;
+
+import java.util.List;
+
+import org.c4marathon.assignment.domain.User;
+import org.c4marathon.assignment.domain.UserRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduledService {
+	private final UserRepository userRepository;
+
+	/**
+	 * 유저 인당 한도 초기화 벌크 연산
+	 */
+	@Scheduled(cron = "${user.charge-limit-initialization.execution-time}")
+	public void initChargeLimit() {
+		int limit = 1000;
+		List<User> users = userRepository.findAllByCursor(0, limit);
+		while (!users.isEmpty()) {
+			List<Long> userIds = users.stream().mapToLong(User::getId).boxed().toList();
+
+			userRepository.initChargeLimit(userIds);
+
+			users = userRepository.findAllByCursor(users.get(users.size() - 1).getId(), limit);
+		}
+
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/application/ScheduledService.java
+++ b/src/main/java/org/c4marathon/assignment/application/ScheduledService.java
@@ -3,7 +3,6 @@ package org.c4marathon.assignment.application;
 import java.util.List;
 
 import org.c4marathon.assignment.domain.User;
-import org.c4marathon.assignment.domain.UserRepository;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -12,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class ScheduledService {
-	private final UserRepository userRepository;
+	private final UserService userService;
 
 	/**
 	 * 유저 인당 한도 초기화 벌크 연산
@@ -20,13 +19,13 @@ public class ScheduledService {
 	@Scheduled(cron = "${user.charge-limit-initialization.execution-time}")
 	public void initChargeLimit() {
 		int limit = 1000;
-		List<User> users = userRepository.findAllByCursor(0, limit);
+		List<User> users = userService.findAllByCursor(0, limit);
 		while (!users.isEmpty()) {
 			List<Long> userIds = users.stream().mapToLong(User::getId).boxed().toList();
 
-			userRepository.initChargeLimit(userIds);
+			userService.initChargeLimit(userIds);
 
-			users = userRepository.findAllByCursor(users.get(users.size() - 1).getId(), limit);
+			users = userService.findAllByCursor(users.get(users.size() - 1).getId(), limit);
 		}
 
 	}

--- a/src/main/java/org/c4marathon/assignment/application/UserService.java
+++ b/src/main/java/org/c4marathon/assignment/application/UserService.java
@@ -1,0 +1,28 @@
+package org.c4marathon.assignment.application;
+
+import org.c4marathon.assignment.domain.Account;
+import org.c4marathon.assignment.domain.AccountRepository;
+import org.c4marathon.assignment.domain.User;
+import org.c4marathon.assignment.domain.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+	private final UserRepository userRepository;
+	private final AccountRepository accountRepository;
+
+	@Transactional
+	public boolean register(String email) {
+		User createdUser = User.builder().email(email).build();
+		userRepository.save(createdUser);
+
+		Account account = Account.builder().isMain(true).userId(createdUser.getId()).build();
+		accountRepository.save(account);
+
+		return true;
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/application/UserService.java
+++ b/src/main/java/org/c4marathon/assignment/application/UserService.java
@@ -1,5 +1,7 @@
 package org.c4marathon.assignment.application;
 
+import java.util.List;
+
 import org.c4marathon.assignment.domain.Account;
 import org.c4marathon.assignment.domain.AccountRepository;
 import org.c4marathon.assignment.domain.User;
@@ -24,5 +26,14 @@ public class UserService {
 		accountRepository.save(account);
 
 		return true;
+	}
+
+	public List<User> findAllByCursor(long cursor, int limit) {
+		return userRepository.findAllByCursor(cursor, limit);
+	}
+
+	@Transactional
+	public void initChargeLimit(List<Long> userIds) {
+		userRepository.initChargeLimit(userIds);
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/controller/AccountController.java
+++ b/src/main/java/org/c4marathon/assignment/controller/AccountController.java
@@ -1,0 +1,41 @@
+package org.c4marathon.assignment.controller;
+
+import org.c4marathon.assignment.application.AccountService;
+import org.c4marathon.assignment.domain.AccountType;
+import org.c4marathon.assignment.domain.dto.request.TransferRequest;
+import org.c4marathon.assignment.domain.dto.request.WithdrawRequest;
+import org.c4marathon.assignment.domain.dto.response.CreatedAccountInfo;
+import org.c4marathon.assignment.domain.dto.response.TransferResult;
+import org.c4marathon.assignment.domain.dto.response.WithdrawResult;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/account")
+@RequiredArgsConstructor
+public class AccountController {
+	private final AccountService accountService;
+
+	@PostMapping("/create")
+	public ResponseEntity<CreatedAccountInfo> create(@RequestParam long userId, @RequestParam AccountType accountType) {
+		return ResponseEntity.status(HttpStatus.CREATED).body(accountService.create(userId, accountType));
+	}
+
+	@PostMapping("/withdraw")
+	public ResponseEntity<WithdrawResult> withdraw(@RequestBody WithdrawRequest request) {
+		return ResponseEntity.ok(accountService.withdraw(request.accountNumber(), request.money()));
+	}
+
+	@PostMapping("/transfer")
+	public ResponseEntity<TransferResult> transfer(@RequestBody TransferRequest request) {
+		return ResponseEntity.ok(
+			accountService.transfer(request.senderAccountNumber(), request.receiverAccountNumber(), request.money()));
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/controller/UserController.java
+++ b/src/main/java/org/c4marathon/assignment/controller/UserController.java
@@ -1,0 +1,23 @@
+package org.c4marathon.assignment.controller;
+
+import org.c4marathon.assignment.application.UserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/user")
+@RequiredArgsConstructor
+public class UserController {
+	private final UserService userService;
+
+	@PostMapping("/register")
+	public ResponseEntity<Boolean> register(@RequestParam String email) {
+		return ResponseEntity.status(HttpStatus.CREATED).body(userService.register(email));
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/Account.java
+++ b/src/main/java/org/c4marathon/assignment/domain/Account.java
@@ -1,0 +1,60 @@
+package org.c4marathon.assignment.domain;
+
+import java.time.LocalDateTime;
+
+import org.c4marathon.assignment.global.AccountUtils;
+import org.hibernate.annotations.ColumnDefault;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+@Entity
+@Table(name = "account")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Account extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id", nullable = false)
+	private Long id;
+
+	@ColumnDefault("0")
+	@Column(name = "balance", nullable = false)
+	private long balance;
+
+	@Column(name = "account_number", nullable = false, unique = true, length = 50)
+	private String accountNumber;
+
+	@Column(name = "is_main", nullable = false)
+	private boolean isMain;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "account_type", nullable = false, length = 30)
+	private AccountType accountType;
+
+	@Column(name = "user_id", nullable = false)
+	private long userId;
+
+	@Builder
+	private Account(long balance, String accountNumber, boolean isMain, AccountType accountType, Long userId,
+		LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+		super(createdAt, updatedAt, deletedAt);
+		this.balance = balance;
+		this.accountNumber = accountNumber != null ? accountNumber : AccountUtils.getAccountNumber();
+		this.isMain = isMain;
+		this.accountType = accountType != null ? accountType : AccountType.CHECKING;
+		this.userId = userId;
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/AccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/AccountRepository.java
@@ -1,0 +1,19 @@
+package org.c4marathon.assignment.domain;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface AccountRepository extends JpaRepository<Account, Long> {
+	@Modifying
+	@Query("UPDATE Account a SET a.balance = a.balance + :money WHERE a.accountNumber = :accountNumber AND a.balance + :money >= 0")
+	int addBalance(@Param("money") long money, @Param("accountNumber") String accountNumber);
+
+	Optional<Account> findByAccountNumber(String accountNumber);
+
+	@Query("SELECT a FROM Account a WHERE a.userId = :userId AND a.isMain = true")
+	Optional<Account> findMainAccount(Long userId);
+}

--- a/src/main/java/org/c4marathon/assignment/domain/AccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/AccountRepository.java
@@ -10,10 +10,10 @@ import org.springframework.data.repository.query.Param;
 public interface AccountRepository extends JpaRepository<Account, Long> {
 	@Modifying
 	@Query("UPDATE Account a SET a.balance = a.balance + :money WHERE a.accountNumber = :accountNumber AND a.balance + :money >= 0")
-	int addBalance(@Param("money") long money, @Param("accountNumber") String accountNumber);
+	int updateBalance(@Param("accountNumber") String accountNumber, @Param("money") long money);
 
 	Optional<Account> findByAccountNumber(String accountNumber);
 
 	@Query("SELECT a FROM Account a WHERE a.userId = :userId AND a.isMain = true")
-	Optional<Account> findMainAccount(Long userId);
+	Optional<Account> findMainAccount(@Param("userId") Long userId);
 }

--- a/src/main/java/org/c4marathon/assignment/domain/AccountType.java
+++ b/src/main/java/org/c4marathon/assignment/domain/AccountType.java
@@ -1,0 +1,6 @@
+package org.c4marathon.assignment.domain;
+
+public enum AccountType {
+	CHECKING, // 입출금(일반)
+	INSTALLATION // 적금
+}

--- a/src/main/java/org/c4marathon/assignment/domain/BaseEntity.java
+++ b/src/main/java/org/c4marathon/assignment/domain/BaseEntity.java
@@ -1,0 +1,30 @@
+package org.c4marathon.assignment.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@MappedSuperclass
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class BaseEntity {
+
+	@Column(name = "created_at", nullable = false, columnDefinition = "datetime")
+	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at", nullable = false, columnDefinition = "datetime")
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at", columnDefinition = "datetime")
+	private LocalDateTime deletedAt;
+
+	protected BaseEntity(LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+		this.createdAt = createdAt != null ? createdAt : LocalDateTime.now();
+		this.updatedAt = updatedAt != null ? updatedAt : this.createdAt;
+		this.deletedAt = deletedAt;
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/User.java
+++ b/src/main/java/org/c4marathon/assignment/domain/User.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "user")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
-	static final long DEFAULT_WITHDRAW_LIMIT = 3_000_000L;
+	static final long DEFAULT_CHARGE_LIMIT = 3_000_000L;
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,22 +28,18 @@ public class User extends BaseEntity {
 	@Column(name = "email", unique = true, nullable = false, length = 50)
 	private String email;
 
-	@Column(name = "day_withdraw_limit", nullable = false)
-	private long dayWithdrawLimit;
+	@Column(name = "charge_limit", nullable = false)
+	private long chargeLimit;
 
-	@Column(name = "day_withdraw", nullable = false)
-	private long dayWithdraw;
-
-	@Column(name = "last_withdraw_date")
-	private LocalDateTime lastWithdrawDate;
+	@Column(name = "acc_charge", nullable = false)
+	private long accCharge;
 
 	@Builder
 	private User(LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt,
-		String email, Long dayWithdrawLimit, long dayWithdraw, LocalDateTime lastWithdrawDate) {
+		String email, Long chargeLimit, long accCharge, LocalDateTime chargeLimitDate) {
 		super(createdAt, updatedAt, deletedAt);
 		this.email = email;
-		this.dayWithdrawLimit = dayWithdrawLimit != null ? dayWithdrawLimit : DEFAULT_WITHDRAW_LIMIT;
-		this.dayWithdraw = dayWithdraw;
-		this.lastWithdrawDate = lastWithdrawDate != null ? lastWithdrawDate : LocalDateTime.now();
+		this.chargeLimit = chargeLimit != null ? chargeLimit : DEFAULT_CHARGE_LIMIT;
+		this.accCharge = accCharge;
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/domain/User.java
+++ b/src/main/java/org/c4marathon/assignment/domain/User.java
@@ -2,8 +2,6 @@ package org.c4marathon.assignment.domain;
 
 import java.time.LocalDateTime;
 
-import org.hibernate.annotations.ColumnDefault;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/org/c4marathon/assignment/domain/User.java
+++ b/src/main/java/org/c4marathon/assignment/domain/User.java
@@ -1,0 +1,51 @@
+package org.c4marathon.assignment.domain;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.ColumnDefault;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "user")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+	static final long DEFAULT_WITHDRAW_LIMIT = 3_000_000L;
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id", nullable = false)
+	private Long id;
+
+	@Column(name = "email", unique = true, nullable = false, length = 50)
+	private String email;
+
+	@Column(name = "day_withdraw_limit", nullable = false)
+	private long dayWithdrawLimit;
+
+	@Column(name = "day_withdraw", nullable = false)
+	private long dayWithdraw;
+
+	@Column(name = "last_withdraw_date")
+	private LocalDateTime lastWithdrawDate;
+
+	@Builder
+	private User(LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt,
+		String email, Long dayWithdrawLimit, long dayWithdraw, LocalDateTime lastWithdrawDate) {
+		super(createdAt, updatedAt, deletedAt);
+		this.email = email;
+		this.dayWithdrawLimit = dayWithdrawLimit != null ? dayWithdrawLimit : DEFAULT_WITHDRAW_LIMIT;
+		this.dayWithdraw = dayWithdraw;
+		this.lastWithdrawDate = lastWithdrawDate != null ? lastWithdrawDate : LocalDateTime.now();
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/UserRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/UserRepository.java
@@ -1,0 +1,18 @@
+package org.c4marathon.assignment.domain;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+	@Modifying
+	@Query("UPDATE User u SET u.dayWithdrawLimit = 0 WHERE u.id = :id")
+	int initializeWithdrawLimit(Long id);
+
+	@Modifying
+	@Query("UPDATE User u SET u.dayWithdraw = u.dayWithdraw + :money, u.lastWithdrawDate = :withdrawTime WHERE u.id = :id AND u.dayWithdraw + :money <= u.dayWithdrawLimit")
+	int withdraw(Long id, long money, LocalDateTime withdrawTime);
+}

--- a/src/main/java/org/c4marathon/assignment/domain/UserRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/UserRepository.java
@@ -1,18 +1,24 @@
 package org.c4marathon.assignment.domain;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
 	@Modifying
-	@Query("UPDATE User u SET u.dayWithdrawLimit = 0 WHERE u.id = :id")
-	int initializeWithdrawLimit(Long id);
+	@Query("UPDATE User u SET u.chargeLimit = 0 WHERE u.id = :id")
+	int initChargeLimit(@Param("ids") Collection<Long> id);
 
 	@Modifying
-	@Query("UPDATE User u SET u.dayWithdraw = u.dayWithdraw + :money, u.lastWithdrawDate = :withdrawTime WHERE u.id = :id AND u.dayWithdraw + :money <= u.dayWithdrawLimit")
-	int withdraw(Long id, long money, LocalDateTime withdrawTime);
+	@Query("UPDATE User u SET u.accCharge = u.accCharge + :money WHERE u.id = :id AND u.accCharge + :money <= u.chargeLimit")
+	int charge(@Param("id") Long id, @Param("money") long money, @Param("chargeTime") LocalDateTime chargeTime);
+
+	@Query(value = "SELECT * FROM user u WHERE u.id > :cursor LIMIT :limit", nativeQuery = true)
+	List<User> findAllByCursor(@Param("cursor") long cursor, @Param("limit") int limit);
 }

--- a/src/main/java/org/c4marathon/assignment/domain/UserRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/UserRepository.java
@@ -1,6 +1,5 @@
 package org.c4marathon.assignment.domain;
 
-import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 

--- a/src/main/java/org/c4marathon/assignment/domain/UserRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/UserRepository.java
@@ -17,7 +17,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
 	@Modifying
 	@Query("UPDATE User u SET u.accCharge = u.accCharge + :money WHERE u.id = :id AND u.accCharge + :money <= u.chargeLimit")
-	int charge(@Param("id") Long id, @Param("money") long money, @Param("chargeTime") LocalDateTime chargeTime);
+	int charge(@Param("id") Long id, @Param("money") long money);
 
 	@Query(value = "SELECT * FROM user u WHERE u.id > :cursor LIMIT :limit", nativeQuery = true)
 	List<User> findAllByCursor(@Param("cursor") long cursor, @Param("limit") int limit);

--- a/src/main/java/org/c4marathon/assignment/domain/UserRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/UserRepository.java
@@ -12,8 +12,8 @@ import org.springframework.data.repository.query.Param;
 public interface UserRepository extends JpaRepository<User, Long> {
 
 	@Modifying
-	@Query("UPDATE User u SET u.chargeLimit = 0 WHERE u.id = :id")
-	int initChargeLimit(@Param("ids") Collection<Long> id);
+	@Query("UPDATE User u SET u.accCharge = 0 WHERE u.id IN :ids")
+	int initChargeLimit(@Param("ids") Collection<Long> ids);
 
 	@Modifying
 	@Query("UPDATE User u SET u.accCharge = u.accCharge + :money WHERE u.id = :id AND u.accCharge + :money <= u.chargeLimit")

--- a/src/main/java/org/c4marathon/assignment/domain/dto/request/TransferRequest.java
+++ b/src/main/java/org/c4marathon/assignment/domain/dto/request/TransferRequest.java
@@ -1,0 +1,4 @@
+package org.c4marathon.assignment.domain.dto.request;
+
+public record TransferRequest(String senderAccountNumber, String receiverAccountNumber, long money) {
+}

--- a/src/main/java/org/c4marathon/assignment/domain/dto/request/WithdrawRequest.java
+++ b/src/main/java/org/c4marathon/assignment/domain/dto/request/WithdrawRequest.java
@@ -1,0 +1,4 @@
+package org.c4marathon.assignment.domain.dto.request;
+
+public record WithdrawRequest(String accountNumber, long money) {
+}

--- a/src/main/java/org/c4marathon/assignment/domain/dto/response/CreatedAccountInfo.java
+++ b/src/main/java/org/c4marathon/assignment/domain/dto/response/CreatedAccountInfo.java
@@ -1,0 +1,9 @@
+package org.c4marathon.assignment.domain.dto.response;
+
+import java.time.LocalDateTime;
+
+import org.c4marathon.assignment.domain.AccountType;
+
+public record CreatedAccountInfo(String accountNumber, LocalDateTime createdAt, AccountType accountType, long balance,
+								 boolean isMain) {
+}

--- a/src/main/java/org/c4marathon/assignment/domain/dto/response/TransferResult.java
+++ b/src/main/java/org/c4marathon/assignment/domain/dto/response/TransferResult.java
@@ -1,0 +1,4 @@
+package org.c4marathon.assignment.domain.dto.response;
+
+public record TransferResult(String senderAccountNumber, String receiverAccountNumber, long money) {
+}

--- a/src/main/java/org/c4marathon/assignment/domain/dto/response/WithdrawResult.java
+++ b/src/main/java/org/c4marathon/assignment/domain/dto/response/WithdrawResult.java
@@ -1,0 +1,4 @@
+package org.c4marathon.assignment.domain.dto.response;
+
+public record WithdrawResult(long withdrawValue) {
+}

--- a/src/main/java/org/c4marathon/assignment/global/AccountUtils.java
+++ b/src/main/java/org/c4marathon/assignment/global/AccountUtils.java
@@ -1,0 +1,15 @@
+package org.c4marathon.assignment.global;
+
+import java.util.Random;
+import java.util.stream.IntStream;
+
+public class AccountUtils {
+	static final Random RANDOM = new Random();
+	static final int LIMIT = 13;
+
+	public static String getAccountNumber() {
+		StringBuilder accountNumber = new StringBuilder();
+		IntStream.range(0, LIMIT).forEach(i -> accountNumber.append((char)('0' + RANDOM.nextInt(10))));
+		return accountNumber.toString();
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/global/AccountUtils.java
+++ b/src/main/java/org/c4marathon/assignment/global/AccountUtils.java
@@ -3,7 +3,7 @@ package org.c4marathon.assignment.global;
 import java.util.Random;
 import java.util.stream.IntStream;
 
-public class AccountUtils {
+public abstract class AccountUtils {
 	static final Random RANDOM = new Random();
 	static final int LIMIT = 13;
 

--- a/src/main/java/org/c4marathon/assignment/global/CommonUtils.java
+++ b/src/main/java/org/c4marathon/assignment/global/CommonUtils.java
@@ -1,0 +1,11 @@
+package org.c4marathon.assignment.global;
+
+public class CommonUtils {
+	private CommonUtils() {}
+
+	public static long getCeil(long val, long ceilingPoint) {
+		long mul = (val + ceilingPoint - 1) / ceilingPoint;
+
+		return ceilingPoint * mul;
+	}
+}

--- a/src/test/java/org/c4marathon/assignment/application/AccountServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/application/AccountServiceTest.java
@@ -1,0 +1,132 @@
+package org.c4marathon.assignment.application;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import org.c4marathon.assignment.domain.Account;
+import org.c4marathon.assignment.domain.AccountRepository;
+import org.c4marathon.assignment.domain.AccountType;
+import org.c4marathon.assignment.domain.User;
+import org.c4marathon.assignment.domain.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class AccountServiceTest {
+	static final int TEST_USERS = 100;
+
+	@Autowired
+	AccountService accountService;
+	@Autowired
+	AccountRepository accountRepository;
+	@Autowired
+	UserRepository userRepository;
+
+	@AfterEach
+	void tearDown() {
+		userRepository.deleteAllInBatch();
+		accountRepository.deleteAllInBatch();
+	}
+
+	@Test
+	@DisplayName("모든 계좌의 돈이 넉넉하고 충전 한도를 넘지 않는 선에서 임의의 100명이 동시에 1명에게 송금할 수 있다.")
+	void success_transfer_100_to_1_given_normal() throws Exception {
+		// given
+		List<Account> testAccounts = IntStream.range(0, TEST_USERS).mapToObj(i -> {
+			User user = User.builder().email("test" + i).build();
+			User savedUser = userRepository.save(user);
+
+			Account account = Account.builder()
+				.accountNumber(String.valueOf(i))
+				.accountType(AccountType.CHECKING)
+				.balance(i * 10000L)
+				.isMain(false)
+				.userId(savedUser.getId())
+				.build();
+
+			return accountRepository.save(account);
+		}).toList();
+
+		long sendMoney = 10000L;
+
+		// when
+		CountDownLatch countDownLatch = new CountDownLatch(TEST_USERS - 1);
+		ExecutorService threadPool = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+		IntStream.range(1, TEST_USERS).forEach(idx ->
+			threadPool.execute(() -> {
+				try {
+					accountService.transfer(
+						testAccounts.get(idx).getAccountNumber(),
+						testAccounts.get(0).getAccountNumber(),
+						sendMoney);
+				} finally {
+					countDownLatch.countDown();
+				}
+			})
+		);
+
+		countDownLatch.await(5000L, TimeUnit.MILLISECONDS);
+		// then
+		Account account = accountRepository.findById(testAccounts.get(0).getId()).get();
+		assertThat(account.getBalance()).isEqualTo(10000L * (TEST_USERS - 1));
+
+	}
+
+	@Test
+	@DisplayName("일부 예외가 일어남에도 임의의 100명이 동시에 1명에게 송금할 수 있다.")
+	void success_transfer_100_to_1_given_error() throws Exception {
+		// given
+		List<Account> testAccounts = IntStream.range(0, TEST_USERS).mapToObj(i -> {
+			User user = User.builder().email("test" + i).accCharge((i & 1) == 1 ? Integer.MAX_VALUE : 0).build(); // 일부 계좌 충전 불가
+			User savedUser = userRepository.save(user);
+
+			Account account = Account.builder()
+				.accountNumber(String.valueOf(i))
+				.accountType(AccountType.CHECKING)
+				.balance(0L)
+				.isMain(false)
+				.userId(savedUser.getId())
+				.build();
+
+			return accountRepository.save(account);
+		}).toList();
+
+		long sendMoney = 100000L;
+
+		// when
+		AtomicInteger exceptionCount = new AtomicInteger();
+		CountDownLatch countDownLatch = new CountDownLatch(TEST_USERS - 10);
+		ExecutorService threadPool = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+		IntStream.range(10, TEST_USERS).forEach(idx ->
+			threadPool.execute(() -> {
+				try {
+					accountService.transfer(
+						testAccounts.get(idx).getAccountNumber(),
+						testAccounts.get(0).getAccountNumber(),
+						sendMoney);
+				} catch (Exception e) {
+					exceptionCount.getAndIncrement();
+				}finally {
+					countDownLatch.countDown();
+				}
+			})
+		);
+
+		countDownLatch.await(5000L, TimeUnit.MILLISECONDS);
+
+		// then
+		Account account = accountRepository.findById(testAccounts.get(0).getId()).get();
+		assertThat(account.getBalance()).isEqualTo(3000000L); // 충전 한도 도달
+		assertThat(exceptionCount.get()).isEqualTo(60);
+	}
+}


### PR DESCRIPTION
# 구현사항
* 송금
  * 잔액이 부족하다면 10,000원 단위로 충전합니다. 충전 시에는 해당 계좌 사용자 충전 한도를 먼저 비교하고 계좌 충전을 합니다.
  * 인당 한도 초기화는 이제 0시 0분에 벌크 연산 처리합니다. 기존에는 충전 시 한도를 확인 및 지연 초기화했으나 이로 인해 연산마다 한도 업데이트가 일어날 가능성이 있을 것 같아서 한 번에 처리하는 것이 좋다고 판단했습니다.
# 프로그래밍 요구사항
* 송금 트랜잭션의 범위
  * 송금 시에는 다음 과정이 일어납니다.
    1. 송금 가능 계좌인지 확인(적금 계좌는 메인 계좌에서만 송금 가능)
    2. 송금 측 부족한 잔액 확인. 부족하면 한도 내 충전
    3. 계좌 번호 내림차 순으로 금액 업데이트 처리
  
    1-3 까지 과정을 전부 하나의 트랜잭션으로 묶기에는 너무 크다 여겼고, 이에 따라 각 과정을 트랜잭션으로 따로 나누었습니다. 이에 따라 락이 걸리는 시간이 줄어 데드락, 성능 하락 가능성을 줄였습니다.

* 동시 송금 처리
  * 현재로써는 100명이 1명에게 동시 송금하여도 문제는 없으나, 속도가 많이 나지는 않는 느낌입니다. 테스트 시, 3초 언저리가 걸리는데 PC 문제인지 로직 문제인지 알기 어렵습니다. -> 실제로는 1.5초로 확인되었습니다.
* 인당 한도 유효기간의 관리
  * 주기를 변경할 수 있게 해야 한다고 이해하고 주기를 따로 `application.yml` 파일로 관리해 동적 관리가 되도록 했습니다. 만약 인당 한도가 각자 부여되어야 한다면 컬럼으로 따로 추가할 계획입니다.
---
### 아직 생각할 점
데드락 해결을 위해 현재 '사용자 내림차 순 확인' - '계좌 번호 내림차 순 확인' 순서로 트랜잭션을 처리하려고 하고 있지만 추후 조건이 더 늘어날 경우에 관리가 어려울 것 같은데 어떻게 해야 좋은 방안일지 고민 중에 있습니다.
테스트 코드는 현재 동시 송금 부분만 작성된 상태입니다.