### PR TITLE
Feature/opixxx step2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     //mysql
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/src/main/java/org/c4marathon/assignment/account/domain/Account.java
+++ b/src/main/java/org/c4marathon/assignment/account/domain/Account.java
@@ -52,7 +52,7 @@ public class Account extends BaseEntity {
         this.money -= money;
     }
 
-    public boolean isCharge(long money) {
+    public boolean canChargeWithinDailyLimit(long money) {
         if (this.chargeLimit < money) {
             return false;
         }
@@ -64,4 +64,11 @@ public class Account extends BaseEntity {
         return this.money > money;
     }
 
+    public void withdraw(long money) {
+        this.money -= money;
+    }
+
+    public void deposit(long money) {
+        this.money += money;
+    }
 }

--- a/src/main/java/org/c4marathon/assignment/account/domain/Account.java
+++ b/src/main/java/org/c4marathon/assignment/account/domain/Account.java
@@ -44,15 +44,15 @@ public class Account extends BaseEntity {
                 .build();
     }
 
-    public void chargeAccount(long money) {
-        this.money += money;
-    }
-
-    public void minusMoney(long money) {
+    public void withdraw(long money) {
         this.money -= money;
     }
 
-    public boolean canChargeWithinDailyLimit(long money) {
+    public void deposit(long money) {
+        this.money += money;
+    }
+
+    public boolean isChargeWithinDailyLimit(long money) {
         if (this.chargeLimit < money) {
             return false;
         }
@@ -64,11 +64,4 @@ public class Account extends BaseEntity {
         return this.money > money;
     }
 
-    public void withdraw(long money) {
-        this.money -= money;
-    }
-
-    public void deposit(long money) {
-        this.money += money;
-    }
 }

--- a/src/main/java/org/c4marathon/assignment/account/domain/Account.java
+++ b/src/main/java/org/c4marathon/assignment/account/domain/Account.java
@@ -28,9 +28,6 @@ public class Account extends BaseEntity {
     @Column(nullable = false)
     private long chargeLimit;
 
-    @Version
-    private Integer version;
-
     @Builder
     private Account(long money, long chargeLimit) {
         this.money = money;

--- a/src/main/java/org/c4marathon/assignment/account/domain/SavingAccount.java
+++ b/src/main/java/org/c4marathon/assignment/account/domain/SavingAccount.java
@@ -36,9 +36,6 @@ public class SavingAccount extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @Version
-    private Integer version;
-
     @Builder
     private SavingAccount(long balance, Member member) {
         this.balance = balance;

--- a/src/main/java/org/c4marathon/assignment/account/domain/SavingAccount.java
+++ b/src/main/java/org/c4marathon/assignment/account/domain/SavingAccount.java
@@ -52,7 +52,7 @@ public class SavingAccount extends BaseEntity {
                 .build();
     }
 
-    public void addMoney(long money) {
+    public void deposit(long money) {
         this.balance += money;
     }
 }

--- a/src/main/java/org/c4marathon/assignment/account/domain/repository/AccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/account/domain/repository/AccountRepository.java
@@ -1,21 +1,22 @@
 package org.c4marathon.assignment.account.domain.repository;
 
+import java.util.Optional;
+
 import jakarta.persistence.LockModeType;
+
 import org.c4marathon.assignment.account.domain.Account;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.Optional;
-
 public interface AccountRepository extends JpaRepository<Account, Long> {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("""
-    SELECT a
-    FROM Account a
-    WHERE a.id = :id
-    """)
-    Optional<Account> findByIdWithLock(@Param("id") Long id);
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("""
+		SELECT a
+		FROM Account a
+		WHERE a.id = :id
+		""")
+	Optional<Account> findByIdWithLock(@Param("id") Long id);
 }

--- a/src/main/java/org/c4marathon/assignment/account/domain/repository/AccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/account/domain/repository/AccountRepository.java
@@ -1,8 +1,21 @@
 package org.c4marathon.assignment.account.domain.repository;
 
+import jakarta.persistence.LockModeType;
 import org.c4marathon.assignment.account.domain.Account;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface AccountRepository extends JpaRepository<Account, Long> {
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+    SELECT a
+    FROM Account a
+    WHERE a.id = :id
+    """)
+    Optional<Account> findByIdWithLock(@Param("id") Long id);
 }

--- a/src/main/java/org/c4marathon/assignment/account/dto/WithdrawRequest.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/WithdrawRequest.java
@@ -1,0 +1,14 @@
+package org.c4marathon.assignment.account.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record WithdrawRequest(
+
+        @NotNull
+        Long receiverAccountId,
+
+        @PositiveOrZero
+        long money
+) {
+}

--- a/src/main/java/org/c4marathon/assignment/account/presentation/AccountController.java
+++ b/src/main/java/org/c4marathon/assignment/account/presentation/AccountController.java
@@ -4,9 +4,11 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 import org.c4marathon.assignment.account.dto.SendToSavingAccountRequest;
+import org.c4marathon.assignment.account.dto.WithdrawRequest;
 import org.c4marathon.assignment.account.service.AccountService;
 import org.c4marathon.assignment.global.annotation.Login;
 import org.c4marathon.assignment.global.session.SessionMemberInfo;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -39,5 +41,14 @@ public class AccountController {
                 request.money()
         );
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/withdraw")
+    public ResponseEntity<Void> withdraw(
+            @Login SessionMemberInfo loginMember,
+            @Valid @RequestBody WithdrawRequest request
+    ) {
+        accountService.withdraw(loginMember.accountId(), request);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
@@ -2,7 +2,7 @@ package org.c4marathon.assignment.account.service;
 
 import static org.c4marathon.assignment.global.util.Const.*;
 
-import lombok.RequiredArgsConstructor;
+import java.util.UUID;
 
 import org.c4marathon.assignment.account.domain.Account;
 import org.c4marathon.assignment.account.domain.SavingAccount;
@@ -11,7 +11,6 @@ import org.c4marathon.assignment.account.domain.repository.SavingAccountReposito
 import org.c4marathon.assignment.account.dto.WithdrawRequest;
 import org.c4marathon.assignment.account.exception.DailyChargeLimitExceededException;
 import org.c4marathon.assignment.account.exception.NotFoundAccountException;
-import org.c4marathon.assignment.global.util.Const;
 import org.c4marathon.assignment.global.util.StringUtil;
 import org.c4marathon.assignment.member.domain.Member;
 import org.c4marathon.assignment.member.domain.repository.MemberRepository;
@@ -21,7 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
@@ -104,7 +104,7 @@ public class AccountService {
 
         redisTemplate.opsForList().rightPush(
                 "pending-deposits",
-                StringUtil.format("{} : {} : {} : {}", transactionId, senderAccountId, request.receiverAccountId(), request.money())
+                StringUtil.format("{}:{}:{}:{}", transactionId, senderAccountId, request.receiverAccountId(), request.money())
         );
     }
 

--- a/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
@@ -52,7 +52,7 @@ public class AccountService {
     //기본값 -> Repeatable Read
     @Transactional(isolation = Isolation.READ_COMMITTED)
     public void chargeMoney(Long accountId, long money) {
-        Account account = accountRepository.findById(accountId)
+        Account account = accountRepository.findByIdWithLock(accountId)
                 .orElseThrow(NotFoundAccountException::new);
 
         if (!account.isChargeWithinDailyLimit(money)) {
@@ -65,7 +65,7 @@ public class AccountService {
 
     @Transactional(isolation = Isolation.READ_COMMITTED)
     public void sendToSavingAccount(Long accountId, Long savingAccountId, long money) {
-        Account account = accountRepository.findById(accountId)
+        Account account = accountRepository.findByIdWithLock(accountId)
                 .orElseThrow(NotFoundAccountException::new);
 
         if (!account.isSend(money)) {

--- a/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
@@ -11,7 +11,7 @@ import org.c4marathon.assignment.account.domain.repository.SavingAccountReposito
 import org.c4marathon.assignment.account.dto.WithdrawRequest;
 import org.c4marathon.assignment.account.exception.DailyChargeLimitExceededException;
 import org.c4marathon.assignment.account.exception.NotFoundAccountException;
-import org.c4marathon.assignment.global.event.WithdrawCompletedEvent;
+import org.c4marathon.assignment.global.event.withdraw.WithdrawCompletedEvent;
 import org.c4marathon.assignment.member.domain.Member;
 import org.c4marathon.assignment.member.domain.repository.MemberRepository;
 import org.c4marathon.assignment.member.exception.NotFoundMemberException;
@@ -110,6 +110,15 @@ public class AccountService {
 		);
 	}
 
+	@Transactional(isolation = Isolation.READ_COMMITTED)
+	public void rollbackWithdraw(Long senderAccountId, long money) {
+		Account senderAccount = accountRepository.findByIdWithLock(senderAccountId)
+			.orElseThrow(NotFoundAccountException::new);
+
+		senderAccount.deposit(money);
+		accountRepository.save(senderAccount);
+	}
+
 	/**
 	 * 송금할 때 메인 계좌에 잔액이 부족할 때 10,000원 단위로 충전하는 로직
 	 * @param money
@@ -126,4 +135,5 @@ public class AccountService {
 
 		senderAccount.deposit(chargeMoney);
 	}
+
 }

--- a/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
@@ -82,34 +82,14 @@ public class AccountService {
         savingAccountRepository.save(savingAccount);
     }
 
+
     /**
-     * 송금 시 출금하는 로직
-     * 잔액 확인 후 잔액 부족시 10,000 단위로 충전 후 Redis Hash 에다가 금액을 누적
+     * 출금 시 Redis List 에 출금 기록을 저장
      * @param senderAccountId
      * @param request
      */
     @Transactional(isolation = Isolation.READ_COMMITTED)
     public void withdraw(Long senderAccountId, WithdrawRequest request) {
-        Account senderAccount = accountRepository.findByIdWithLock(senderAccountId)
-                .orElseThrow(NotFoundAccountException::new);
-
-        if (!senderAccount.isSend(request.money())) {
-            autoCharge(request.money(), senderAccount);
-        }
-
-        senderAccount.withdraw(request.money());
-        accountRepository.save(senderAccount);
-
-
-        redisTemplate.opsForHash().increment(
-                "pending-deposits",
-                request.receiverAccountId(),
-                request.money()
-        );
-    }
-
-    @Transactional(isolation = Isolation.READ_COMMITTED)
-    public void withdraw2(Long senderAccountId, WithdrawRequest request) {
         Account senderAccount = accountRepository.findByIdWithLock(senderAccountId)
                 .orElseThrow(NotFoundAccountException::new);
 
@@ -145,4 +125,23 @@ public class AccountService {
         senderAccount.deposit(chargeMoney);
     }
 
+   /* @Transactional(isolation = Isolation.READ_COMMITTED)
+    public void withdraw(Long senderAccountId, WithdrawRequest request) {
+        Account senderAccount = accountRepository.findByIdWithLock(senderAccountId)
+                .orElseThrow(NotFoundAccountException::new);
+
+        if (!senderAccount.isSend(request.money())) {
+            autoCharge(request.money(), senderAccount);
+        }
+
+        senderAccount.withdraw(request.money());
+        accountRepository.save(senderAccount);
+
+
+        redisTemplate.opsForHash().increment(
+                "pending-deposits",
+                request.receiverAccountId(),
+                request.money()
+        );
+    }*/
 }

--- a/src/main/java/org/c4marathon/assignment/account/service/DepositService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/DepositService.java
@@ -10,7 +10,9 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
-import java.util.Map;
+import java.util.List;
+
+import static org.c4marathon.assignment.global.util.Const.MAX_RETRIES;
 
 
 @Slf4j
@@ -18,16 +20,122 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class DepositService {
     private final AccountRepository accountRepository;
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisTemplate<String, String> redisTemplate;
     private final MiniPayThreadPoolExecutor threadPoolExecutor = new MiniPayThreadPoolExecutor(8, 32);
+
 
     @Scheduled(fixedRate = 10000)
     public void deposits() {
         threadPoolExecutor.init();
 
+        List<String> deposits = redisTemplate.opsForList().range("pending-deposits", 0, -1);
+        if (deposits == null || deposits.isEmpty()) {
+            return;
+        }
+
+        for (String deposit : deposits) {
+            threadPoolExecutor.execute(() -> processDeposit(deposit));
+        }
+
+        try {
+            threadPoolExecutor.waitToEnd();
+        } catch (Exception e) {
+            log.error("스레드 풀 실행 중 예외 발생 : {}", e.getMessage(), e);
+        }
+    }
+
+
+    /**
+     * 입금 실패한 경우가 많이 없을 것이라고 생각하여 멀티 스레드 X
+     *  나중에 멀티 스레드 성능 테스트 후 결정
+     */
+    @Scheduled(fixedRate = 12000)
+    public void rollbackDeposits() {
+        List<String> failedDeposits = redisTemplate.opsForList().range("failed-deposits", 0, -1);
+        if (failedDeposits == null || failedDeposits.isEmpty()) {
+            return;
+        }
+
+        for (String depositRequest : failedDeposits) {
+            processFailedDeposit(depositRequest);
+        }
+    }
+
+    private void processDeposit(String deposit) {
+        String[] parts = deposit.split(":");
+        String transactionId = parts[0];
+        Long senderAccountId = Long.valueOf(parts[1]);
+        Long receiverAccountId = Long.valueOf(parts[2]);
+        long money = Long.parseLong(parts[3]);
+
+        try {
+            redisTemplate.opsForList().remove("pending-deposits", 1, deposit);
+
+            Account receiverAccount = accountRepository.findByIdWithLock(receiverAccountId)
+                    .orElseThrow(NotFoundAccountException::new);
+
+            receiverAccount.deposit(money);
+            accountRepository.save(receiverAccount);
+
+            log.debug("입금 성공: transactionId={}, senderAccountId={}, receiverAccountId={}, money={}",
+                    transactionId, senderAccountId, receiverAccountId, money);
+        } catch (Exception e) {
+            redisTemplate.opsForList().rightPush("failed-deposits", deposit);
+            log.debug("입금 실패: transactionId={}, senderAccountId={}, receiverAccountId={}, money={}",
+                    transactionId, senderAccountId, receiverAccountId, money);
+
+        }
+    }
+
+    private void processFailedDeposit(String failedDeposit) {
+        String[] parts = failedDeposit.split(":");
+        String transactionId = parts[0];
+        Long senderAccountId = Long.valueOf(parts[1]);
+        Long receiverAccountId = Long.valueOf(parts[2]);
+        long money = Long.parseLong(parts[3]);
+
+        try {
+            Account receiverAccount = accountRepository.findByIdWithLock(receiverAccountId)
+                    .orElseThrow(NotFoundAccountException::new);
+
+            receiverAccount.deposit(money);
+            accountRepository.save(receiverAccount);
+            redisTemplate.opsForList().remove("failed-deposits", 1, failedDeposit);
+            log.debug("입금 재시도 성공: transactionId={}, senderAccountId={}, receiverAccountId={}, money={}",
+                    transactionId, senderAccountId, receiverAccountId, money);
+        } catch (Exception e) {
+            log.debug("입금 재시도 실패: transactionId={}, senderAccountId={}, receiverAccountId={}, money={}",
+                    transactionId, senderAccountId, receiverAccountId, money);
+
+            int retryCount = redisTemplate.opsForValue().increment("deposit-failures:" + transactionId).intValue();
+
+            if (retryCount > MAX_RETRIES) {
+                log.error("입금 실패 횟수 초과, 출금 롤백 진행: transactionId={}, senderId={}, money={}", transactionId, senderAccountId, money);
+
+                redisTemplate.opsForList().remove("failed-deposits", 1, failedDeposit);
+                rollbackWithdraw(senderAccountId, money);
+
+                redisTemplate.delete("deposit-failures:" + transactionId);
+            }
+        }
+    }
+
+    private void rollbackWithdraw(Long senderAccountId, long money) {
+        Account senderAccount = accountRepository.findByIdWithLock(senderAccountId)
+                .orElseThrow(NotFoundAccountException::new);
+
+        senderAccount.deposit(money);
+        accountRepository.save(senderAccount);
+    }
+
+
+
+  /*  @Scheduled(fixedRate = 10000)
+    public void deposits() {
+        threadPoolExecutor.init();
+
         Map<Object, Object> deposits = redisTemplate.opsForHash().entries("pending-deposits");
         if (deposits.isEmpty()) return;
-
 
         for (Map.Entry<Object, Object> entry : deposits.entrySet()) {
             threadPoolExecutor.execute(() -> {
@@ -56,4 +164,39 @@ public class DepositService {
             log.error("스레드 풀 실행 중 예외 발생 : {}", e.getMessage(), e);
         }
     }
+
+    *//**
+     * 입금 실패한 경우가 많이 없을 것이라고 생각하여 멀티 스레드 X
+     * 나중에 멀티 스레드 성능 테스트 후 결정
+     * 서버에 문제가 있어 아무리 재시도 해도 입금이 안되는 경우는 어떻게 처리해야할지 고민
+     *//*
+    @Scheduled(fixedRate = 12000)
+    public void rollbackDeposits() {
+        threadPoolExecutor.init();
+
+        Map<Object, Object> failedDeposits = redisTemplate.opsForHash().entries("failed-deposits");
+
+        if (failedDeposits.isEmpty()) {
+            return;
+        }
+
+        for (Map.Entry<Object, Object> entry : failedDeposits.entrySet()) {
+            Long receiverId = Long.valueOf(entry.getKey().toString());
+            long totalAmount = Long.parseLong(entry.getValue().toString());
+
+            try {
+                Account receiverAccount = accountRepository.findByIdWithLock(receiverId)
+                        .orElseThrow(NotFoundAccountException::new);
+
+                receiverAccount.deposit(totalAmount);
+                accountRepository.save(receiverAccount);
+
+                redisTemplate.opsForHash().delete("failed-deposits", receiverId);
+            } catch (Exception e) {
+                log.error("입금 처리 실패 : receiverId = {}, amount = {}", receiverId, totalAmount);
+            }
+        }
+
+    }*/
+
 }

--- a/src/main/java/org/c4marathon/assignment/account/service/DepositService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/DepositService.java
@@ -1,62 +1,42 @@
 package org.c4marathon.assignment.account.service;
 
-import static org.c4marathon.assignment.global.util.Const.*;
-
-import java.util.List;
-
 import org.c4marathon.assignment.account.domain.Account;
 import org.c4marathon.assignment.account.domain.repository.AccountRepository;
 import org.c4marathon.assignment.account.exception.NotFoundAccountException;
-import org.c4marathon.assignment.global.core.MiniPayThreadPoolExecutor;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.scheduling.annotation.Scheduled;
+import org.c4marathon.assignment.global.event.deposit.DepositCompletedEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class DepositService {
 	private final AccountRepository accountRepository;
-	private final RedisTemplate<String, String> redisTemplate;
-	private final MiniPayThreadPoolExecutor threadPoolExecutor = new MiniPayThreadPoolExecutor(8, 32);
-
-	@Scheduled(fixedRate = 10000)
-	public void deposits() {
-		threadPoolExecutor.init();
-
-		List<String> deposits = redisTemplate.opsForList().range(PENDING_DEPOSIT, 0, -1);
-		if (deposits == null || deposits.isEmpty()) {
-			return;
-		}
-
-		for (String deposit : deposits) {
-			threadPoolExecutor.execute(() -> processDeposit(deposit));
-		}
-
-		try {
-			threadPoolExecutor.waitToEnd();
-		} catch (Exception e) {
-			log.error("스레드 풀 실행 중 예외 발생 : {}", e.getMessage(), e);
-		}
-	}
+	private final ApplicationEventPublisher eventPublisher;
 
 	/**
-	 * 입금 실패한 경우가 많이 없을 것이라고 생각하여 멀티 스레드 X
-	 *  나중에 멀티 스레드 성능 테스트 후 결정
+	 * 입금을 시도하는 로직.
+	 * 입금이 정상적으로 커밋 완료 시 -> 이벤트 발행을 하며 Redis에 저장된 송금 기록을 삭제
+	 * 입금 중 예외가 발생 시 -> AOP를 통해 예외를 감지하여 Redis에 실패 송금 기록을 저장
+	 * @param deposit
 	 */
-	@Scheduled(fixedRate = 12000)
-	public void rollbackDeposits() {
-		List<String> failedDeposits = redisTemplate.opsForList().range(FAILED_DEPOSIT, 0, -1);
-		if (failedDeposits == null || failedDeposits.isEmpty()) {
-			return;
-		}
-
-		for (String depositRequest : failedDeposits) {
-			processFailedDeposit(depositRequest);
-		}
+	@Transactional(isolation = Isolation.READ_COMMITTED)
+	public void successDeposit(String deposit) {
+		processDeposit(deposit);
+	}
+	/**
+	 * 실패한 입금을 재시도하는 로직
+	 * 재입금이 정상적으로 커밋 완료 시 -> 이벤트 발행을 하며 Redis에 저장된 송금 기록을 삭제
+	 * 재입금 중 예외(실패) 시 -> AOP를 통해 예외를 감지하여 송금 롤백 시도
+	 * @param failedDeposit
+	 */
+	@Transactional(isolation = Isolation.READ_COMMITTED)
+	public void failedDeposit(String failedDeposit) {
+		processDeposit(failedDeposit);
 	}
 
 	private void processDeposit(String deposit) {
@@ -66,64 +46,12 @@ public class DepositService {
 		Long receiverAccountId = Long.valueOf(parts[2]);
 		long money = Long.parseLong(parts[3]);
 
-		try {
-			redisTemplate.opsForList().remove(PENDING_DEPOSIT, 1, deposit);
-
-			Account receiverAccount = accountRepository.findByIdWithLock(receiverAccountId)
-				.orElseThrow(NotFoundAccountException::new);
-
-			receiverAccount.deposit(money);
-			accountRepository.save(receiverAccount);
-
-			log.debug("입금 성공: transactionId={}, senderAccountId={}, receiverAccountId={}, money={}",
-				transactionId, senderAccountId, receiverAccountId, money);
-		} catch (Exception e) {
-			redisTemplate.opsForList().rightPush(FAILED_DEPOSIT, deposit);
-			log.debug("입금 실패: transactionId={}, senderAccountId={}, receiverAccountId={}, money={}",
-				transactionId, senderAccountId, receiverAccountId, money);
-
-		}
-	}
-
-	private void processFailedDeposit(String failedDeposit) {
-		String[] parts = failedDeposit.split(":");
-		String transactionId = parts[0];
-		Long senderAccountId = Long.valueOf(parts[1]);
-		Long receiverAccountId = Long.valueOf(parts[2]);
-		long money = Long.parseLong(parts[3]);
-
-		try {
-			Account receiverAccount = accountRepository.findByIdWithLock(receiverAccountId)
-				.orElseThrow(NotFoundAccountException::new);
-
-			receiverAccount.deposit(money);
-			accountRepository.save(receiverAccount);
-			redisTemplate.opsForList().remove(FAILED_DEPOSIT, 1, failedDeposit);
-			log.debug("입금 재시도 성공: transactionId={}, senderAccountId={}, receiverAccountId={}, money={}",
-				transactionId, senderAccountId, receiverAccountId, money);
-		} catch (Exception e) {
-			log.debug("입금 재시도 실패: transactionId={}, senderAccountId={}, receiverAccountId={}, money={}",
-				transactionId, senderAccountId, receiverAccountId, money);
-
-			int retryCount = redisTemplate.opsForValue().increment("deposit-failures:" + transactionId).intValue();
-
-			if (retryCount > MAX_RETRIES) {
-				log.error("입금 실패 횟수 초과, 출금 롤백 진행: transactionId={}, senderId={}, money={}", transactionId,
-					senderAccountId, money);
-
-				redisTemplate.opsForList().remove(FAILED_DEPOSIT, 1, failedDeposit);
-				rollbackWithdraw(senderAccountId, money);
-
-				redisTemplate.delete("deposit-failures:" + transactionId);
-			}
-		}
-	}
-
-	private void rollbackWithdraw(Long senderAccountId, long money) {
-		Account senderAccount = accountRepository.findByIdWithLock(senderAccountId)
+		Account receiverAccount = accountRepository.findByIdWithLock(receiverAccountId)
 			.orElseThrow(NotFoundAccountException::new);
 
-		senderAccount.deposit(money);
-		accountRepository.save(senderAccount);
+		receiverAccount.deposit(money);
+		accountRepository.save(receiverAccount);
+
+		eventPublisher.publishEvent(new DepositCompletedEvent(deposit));
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/account/service/DepositService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/DepositService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class DepositService {
@@ -28,6 +29,7 @@ public class DepositService {
 	public void successDeposit(String deposit) {
 		processDeposit(deposit);
 	}
+
 	/**
 	 * 실패한 입금을 재시도하는 로직
 	 * 재입금이 정상적으로 커밋 완료 시 -> 이벤트 발행을 하며 Redis에 저장된 송금 기록을 삭제
@@ -53,5 +55,8 @@ public class DepositService {
 		accountRepository.save(receiverAccount);
 
 		eventPublisher.publishEvent(new DepositCompletedEvent(deposit));
+
+		log.debug("입금 성공 : transactionId : {}, senderAccountId : {}, receiverAccountId : {}, money : {}",
+			transactionId, senderAccountId, receiverAccountId, money);
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/account/service/DepositService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/DepositService.java
@@ -1,0 +1,59 @@
+package org.c4marathon.assignment.account.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.c4marathon.assignment.account.domain.Account;
+import org.c4marathon.assignment.account.domain.repository.AccountRepository;
+import org.c4marathon.assignment.account.exception.NotFoundAccountException;
+import org.c4marathon.assignment.global.core.MiniPayThreadPoolExecutor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DepositService {
+    private final AccountRepository accountRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final MiniPayThreadPoolExecutor threadPoolExecutor = new MiniPayThreadPoolExecutor(8, 32);
+
+    @Scheduled(fixedRate = 10000)
+    public void deposits() {
+        threadPoolExecutor.init();
+
+        Map<Object, Object> deposits = redisTemplate.opsForHash().entries("pending-deposits");
+        if (deposits.isEmpty()) return;
+
+
+        for (Map.Entry<Object, Object> entry : deposits.entrySet()) {
+            threadPoolExecutor.execute(() -> {
+
+                Long receiverId = Long.valueOf(entry.getKey().toString());
+                long totalAmount = Long.parseLong(entry.getValue().toString());
+
+                try {
+                    Account receiverAccount = accountRepository.findByIdWithLock(receiverId)
+                            .orElseThrow(NotFoundAccountException::new);
+
+                    receiverAccount.deposit(totalAmount);
+                    accountRepository.save(receiverAccount);
+
+                    redisTemplate.opsForHash().delete("pending-deposits", receiverId);
+                } catch (Exception e) {
+                    log.error("입금 처리 실패 : receiverId = {}, amount = {}", receiverId, totalAmount);
+                    redisTemplate.opsForHash().increment("failed-deposits", receiverId, totalAmount);
+                }
+            });
+        }
+
+        try {
+            threadPoolExecutor.waitToEnd();
+        } catch (Exception e) {
+            log.error("스레드 풀 실행 중 예외 발생 : {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/org/c4marathon/assignment/account/service/DepositService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/DepositService.java
@@ -1,7 +1,10 @@
 package org.c4marathon.assignment.account.service;
 
+import static org.c4marathon.assignment.global.util.Const.*;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.c4marathon.assignment.account.domain.Account;
 import org.c4marathon.assignment.account.domain.repository.AccountRepository;
 import org.c4marathon.assignment.account.exception.NotFoundAccountException;
@@ -12,191 +15,115 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-import static org.c4marathon.assignment.global.util.Const.MAX_RETRIES;
-
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class DepositService {
-    private final AccountRepository accountRepository;
-    private final RedisTemplate<String, String> redisTemplate;
-    private final MiniPayThreadPoolExecutor threadPoolExecutor = new MiniPayThreadPoolExecutor(8, 32);
+	private final AccountRepository accountRepository;
+	private final RedisTemplate<String, String> redisTemplate;
+	private final MiniPayThreadPoolExecutor threadPoolExecutor = new MiniPayThreadPoolExecutor(8, 32);
 
+	@Scheduled(fixedRate = 10000)
+	public void deposits() {
+		threadPoolExecutor.init();
 
-    @Scheduled(fixedRate = 10000)
-    public void deposits() {
-        threadPoolExecutor.init();
+		List<String> deposits = redisTemplate.opsForList().range(PENDING_DEPOSIT, 0, -1);
+		if (deposits == null || deposits.isEmpty()) {
+			return;
+		}
 
-        List<String> deposits = redisTemplate.opsForList().range("pending-deposits", 0, -1);
-        if (deposits == null || deposits.isEmpty()) {
-            return;
-        }
+		for (String deposit : deposits) {
+			threadPoolExecutor.execute(() -> processDeposit(deposit));
+		}
 
-        for (String deposit : deposits) {
-            threadPoolExecutor.execute(() -> processDeposit(deposit));
-        }
+		try {
+			threadPoolExecutor.waitToEnd();
+		} catch (Exception e) {
+			log.error("스레드 풀 실행 중 예외 발생 : {}", e.getMessage(), e);
+		}
+	}
 
-        try {
-            threadPoolExecutor.waitToEnd();
-        } catch (Exception e) {
-            log.error("스레드 풀 실행 중 예외 발생 : {}", e.getMessage(), e);
-        }
-    }
+	/**
+	 * 입금 실패한 경우가 많이 없을 것이라고 생각하여 멀티 스레드 X
+	 *  나중에 멀티 스레드 성능 테스트 후 결정
+	 */
+	@Scheduled(fixedRate = 12000)
+	public void rollbackDeposits() {
+		List<String> failedDeposits = redisTemplate.opsForList().range(FAILED_DEPOSIT, 0, -1);
+		if (failedDeposits == null || failedDeposits.isEmpty()) {
+			return;
+		}
 
+		for (String depositRequest : failedDeposits) {
+			processFailedDeposit(depositRequest);
+		}
+	}
 
-    /**
-     * 입금 실패한 경우가 많이 없을 것이라고 생각하여 멀티 스레드 X
-     *  나중에 멀티 스레드 성능 테스트 후 결정
-     */
-    @Scheduled(fixedRate = 12000)
-    public void rollbackDeposits() {
-        List<String> failedDeposits = redisTemplate.opsForList().range("failed-deposits", 0, -1);
-        if (failedDeposits == null || failedDeposits.isEmpty()) {
-            return;
-        }
+	private void processDeposit(String deposit) {
+		String[] parts = deposit.split(":");
+		String transactionId = parts[0];
+		Long senderAccountId = Long.valueOf(parts[1]);
+		Long receiverAccountId = Long.valueOf(parts[2]);
+		long money = Long.parseLong(parts[3]);
 
-        for (String depositRequest : failedDeposits) {
-            processFailedDeposit(depositRequest);
-        }
-    }
+		try {
+			redisTemplate.opsForList().remove(PENDING_DEPOSIT, 1, deposit);
 
-    private void processDeposit(String deposit) {
-        String[] parts = deposit.split(":");
-        String transactionId = parts[0];
-        Long senderAccountId = Long.valueOf(parts[1]);
-        Long receiverAccountId = Long.valueOf(parts[2]);
-        long money = Long.parseLong(parts[3]);
+			Account receiverAccount = accountRepository.findByIdWithLock(receiverAccountId)
+				.orElseThrow(NotFoundAccountException::new);
 
-        try {
-            redisTemplate.opsForList().remove("pending-deposits", 1, deposit);
+			receiverAccount.deposit(money);
+			accountRepository.save(receiverAccount);
 
-            Account receiverAccount = accountRepository.findByIdWithLock(receiverAccountId)
-                    .orElseThrow(NotFoundAccountException::new);
+			log.debug("입금 성공: transactionId={}, senderAccountId={}, receiverAccountId={}, money={}",
+				transactionId, senderAccountId, receiverAccountId, money);
+		} catch (Exception e) {
+			redisTemplate.opsForList().rightPush(FAILED_DEPOSIT, deposit);
+			log.debug("입금 실패: transactionId={}, senderAccountId={}, receiverAccountId={}, money={}",
+				transactionId, senderAccountId, receiverAccountId, money);
 
-            receiverAccount.deposit(money);
-            accountRepository.save(receiverAccount);
+		}
+	}
 
-            log.debug("입금 성공: transactionId={}, senderAccountId={}, receiverAccountId={}, money={}",
-                    transactionId, senderAccountId, receiverAccountId, money);
-        } catch (Exception e) {
-            redisTemplate.opsForList().rightPush("failed-deposits", deposit);
-            log.debug("입금 실패: transactionId={}, senderAccountId={}, receiverAccountId={}, money={}",
-                    transactionId, senderAccountId, receiverAccountId, money);
+	private void processFailedDeposit(String failedDeposit) {
+		String[] parts = failedDeposit.split(":");
+		String transactionId = parts[0];
+		Long senderAccountId = Long.valueOf(parts[1]);
+		Long receiverAccountId = Long.valueOf(parts[2]);
+		long money = Long.parseLong(parts[3]);
 
-        }
-    }
+		try {
+			Account receiverAccount = accountRepository.findByIdWithLock(receiverAccountId)
+				.orElseThrow(NotFoundAccountException::new);
 
-    private void processFailedDeposit(String failedDeposit) {
-        String[] parts = failedDeposit.split(":");
-        String transactionId = parts[0];
-        Long senderAccountId = Long.valueOf(parts[1]);
-        Long receiverAccountId = Long.valueOf(parts[2]);
-        long money = Long.parseLong(parts[3]);
+			receiverAccount.deposit(money);
+			accountRepository.save(receiverAccount);
+			redisTemplate.opsForList().remove(FAILED_DEPOSIT, 1, failedDeposit);
+			log.debug("입금 재시도 성공: transactionId={}, senderAccountId={}, receiverAccountId={}, money={}",
+				transactionId, senderAccountId, receiverAccountId, money);
+		} catch (Exception e) {
+			log.debug("입금 재시도 실패: transactionId={}, senderAccountId={}, receiverAccountId={}, money={}",
+				transactionId, senderAccountId, receiverAccountId, money);
 
-        try {
-            Account receiverAccount = accountRepository.findByIdWithLock(receiverAccountId)
-                    .orElseThrow(NotFoundAccountException::new);
+			int retryCount = redisTemplate.opsForValue().increment("deposit-failures:" + transactionId).intValue();
 
-            receiverAccount.deposit(money);
-            accountRepository.save(receiverAccount);
-            redisTemplate.opsForList().remove("failed-deposits", 1, failedDeposit);
-            log.debug("입금 재시도 성공: transactionId={}, senderAccountId={}, receiverAccountId={}, money={}",
-                    transactionId, senderAccountId, receiverAccountId, money);
-        } catch (Exception e) {
-            log.debug("입금 재시도 실패: transactionId={}, senderAccountId={}, receiverAccountId={}, money={}",
-                    transactionId, senderAccountId, receiverAccountId, money);
+			if (retryCount > MAX_RETRIES) {
+				log.error("입금 실패 횟수 초과, 출금 롤백 진행: transactionId={}, senderId={}, money={}", transactionId,
+					senderAccountId, money);
 
-            int retryCount = redisTemplate.opsForValue().increment("deposit-failures:" + transactionId).intValue();
+				redisTemplate.opsForList().remove(FAILED_DEPOSIT, 1, failedDeposit);
+				rollbackWithdraw(senderAccountId, money);
 
-            if (retryCount > MAX_RETRIES) {
-                log.error("입금 실패 횟수 초과, 출금 롤백 진행: transactionId={}, senderId={}, money={}", transactionId, senderAccountId, money);
+				redisTemplate.delete("deposit-failures:" + transactionId);
+			}
+		}
+	}
 
-                redisTemplate.opsForList().remove("failed-deposits", 1, failedDeposit);
-                rollbackWithdraw(senderAccountId, money);
+	private void rollbackWithdraw(Long senderAccountId, long money) {
+		Account senderAccount = accountRepository.findByIdWithLock(senderAccountId)
+			.orElseThrow(NotFoundAccountException::new);
 
-                redisTemplate.delete("deposit-failures:" + transactionId);
-            }
-        }
-    }
-
-    private void rollbackWithdraw(Long senderAccountId, long money) {
-        Account senderAccount = accountRepository.findByIdWithLock(senderAccountId)
-                .orElseThrow(NotFoundAccountException::new);
-
-        senderAccount.deposit(money);
-        accountRepository.save(senderAccount);
-    }
-
-
-
-  /*  @Scheduled(fixedRate = 10000)
-    public void deposits() {
-        threadPoolExecutor.init();
-
-        Map<Object, Object> deposits = redisTemplate.opsForHash().entries("pending-deposits");
-        if (deposits.isEmpty()) return;
-
-        for (Map.Entry<Object, Object> entry : deposits.entrySet()) {
-            threadPoolExecutor.execute(() -> {
-
-                Long receiverId = Long.valueOf(entry.getKey().toString());
-                long totalAmount = Long.parseLong(entry.getValue().toString());
-
-                try {
-                    Account receiverAccount = accountRepository.findByIdWithLock(receiverId)
-                            .orElseThrow(NotFoundAccountException::new);
-
-                    receiverAccount.deposit(totalAmount);
-                    accountRepository.save(receiverAccount);
-
-                    redisTemplate.opsForHash().delete("pending-deposits", receiverId);
-                } catch (Exception e) {
-                    log.error("입금 처리 실패 : receiverId = {}, amount = {}", receiverId, totalAmount);
-                    redisTemplate.opsForHash().increment("failed-deposits", receiverId, totalAmount);
-                }
-            });
-        }
-
-        try {
-            threadPoolExecutor.waitToEnd();
-        } catch (Exception e) {
-            log.error("스레드 풀 실행 중 예외 발생 : {}", e.getMessage(), e);
-        }
-    }
-
-    *//**
-     * 입금 실패한 경우가 많이 없을 것이라고 생각하여 멀티 스레드 X
-     * 나중에 멀티 스레드 성능 테스트 후 결정
-     * 서버에 문제가 있어 아무리 재시도 해도 입금이 안되는 경우는 어떻게 처리해야할지 고민
-     *//*
-    @Scheduled(fixedRate = 12000)
-    public void rollbackDeposits() {
-        threadPoolExecutor.init();
-
-        Map<Object, Object> failedDeposits = redisTemplate.opsForHash().entries("failed-deposits");
-
-        if (failedDeposits.isEmpty()) {
-            return;
-        }
-
-        for (Map.Entry<Object, Object> entry : failedDeposits.entrySet()) {
-            Long receiverId = Long.valueOf(entry.getKey().toString());
-            long totalAmount = Long.parseLong(entry.getValue().toString());
-
-            try {
-                Account receiverAccount = accountRepository.findByIdWithLock(receiverId)
-                        .orElseThrow(NotFoundAccountException::new);
-
-                receiverAccount.deposit(totalAmount);
-                accountRepository.save(receiverAccount);
-
-                redisTemplate.opsForHash().delete("failed-deposits", receiverId);
-            } catch (Exception e) {
-                log.error("입금 처리 실패 : receiverId = {}, amount = {}", receiverId, totalAmount);
-            }
-        }
-
-    }*/
-
+		senderAccount.deposit(money);
+		accountRepository.save(senderAccount);
+	}
 }

--- a/src/main/java/org/c4marathon/assignment/account/service/DepositService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/DepositService.java
@@ -2,6 +2,8 @@ package org.c4marathon.assignment.account.service;
 
 import static org.c4marathon.assignment.global.util.Const.*;
 
+import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -13,7 +15,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
 
 @Slf4j
 @Service

--- a/src/main/java/org/c4marathon/assignment/account/service/DepositService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/DepositService.java
@@ -4,9 +4,6 @@ import static org.c4marathon.assignment.global.util.Const.*;
 
 import java.util.List;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import org.c4marathon.assignment.account.domain.Account;
 import org.c4marathon.assignment.account.domain.repository.AccountRepository;
 import org.c4marathon.assignment.account.exception.NotFoundAccountException;
@@ -15,6 +12,8 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service

--- a/src/main/java/org/c4marathon/assignment/account/service/SavingAccountService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/SavingAccountService.java
@@ -1,6 +1,7 @@
 package org.c4marathon.assignment.account.service;
 
-import lombok.RequiredArgsConstructor;
+import static org.c4marathon.assignment.global.util.Const.*;
+
 import org.c4marathon.assignment.account.domain.SavingAccount;
 import org.c4marathon.assignment.account.domain.repository.SavingAccountRepository;
 import org.c4marathon.assignment.account.dto.SavingAccountCreateResponse;
@@ -10,7 +11,7 @@ import org.c4marathon.assignment.member.exception.NotFoundMemberException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.c4marathon.assignment.global.util.Const.DEFAULT_BALANCE;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/org/c4marathon/assignment/account/service/scheduler/DepositScheduler.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/scheduler/DepositScheduler.java
@@ -1,0 +1,59 @@
+package org.c4marathon.assignment.account.service.scheduler;
+
+import static org.c4marathon.assignment.global.util.Const.*;
+
+import java.util.List;
+
+import org.c4marathon.assignment.account.service.DepositService;
+import org.c4marathon.assignment.global.core.MiniPayThreadPoolExecutor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DepositScheduler {
+	private final DepositService depositService;
+	private final RedisTemplate<String, String> redisTemplate;
+	private final MiniPayThreadPoolExecutor threadPoolExecutor = new MiniPayThreadPoolExecutor(8, 32);
+
+	@Scheduled(fixedRate = 10000)
+	public void deposits() {
+		threadPoolExecutor.init();
+
+		List<String> deposits = redisTemplate.opsForList().range(PENDING_DEPOSIT, 0, -1);
+		if (deposits == null || deposits.isEmpty()) {
+			return;
+		}
+
+		for (String deposit : deposits) {
+			threadPoolExecutor.execute(() -> depositService.successDeposit(deposit));
+		}
+
+		try {
+			threadPoolExecutor.waitToEnd();
+		} catch (Exception e) {
+			log.error("스레드 풀 실행 중 예외 발생 : {}", e.getMessage(), e);
+		}
+	}
+
+	/**
+	 * 입금 실패한 경우가 많이 없을 것이라고 생각하여 멀티 스레드 X
+	 *  나중에 멀티 스레드 성능 테스트 후 결정
+	 */
+	@Scheduled(fixedRate = 12000)
+	public void rollbackDeposits() {
+		List<String> failedDeposits = redisTemplate.opsForList().range(FAILED_DEPOSIT, 0, -1);
+		if (failedDeposits == null || failedDeposits.isEmpty()) {
+			return;
+		}
+
+		for (String depositRequest : failedDeposits) {
+			depositService.failedDeposit(depositRequest);
+		}
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/global/aop/DepositFailureHandler.java
+++ b/src/main/java/org/c4marathon/assignment/global/aop/DepositFailureHandler.java
@@ -1,0 +1,45 @@
+package org.c4marathon.assignment.global.aop;
+
+import static org.c4marathon.assignment.global.util.Const.*;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.c4marathon.assignment.account.service.AccountService;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class DepositFailureHandler {
+	private final RedisTemplate<String, String> redisTemplate;
+	private final AccountService accountService;
+
+	@AfterThrowing(pointcut = "execution(* org.c4marathon.assignment.account.service.DepositService.successDeposit(..))",
+		throwing = "ex")
+	public void handleDepositFailure(JoinPoint joinPoint, Exception ex) {
+
+		Object[] args = joinPoint.getArgs();
+		String deposit = (String) args[0];
+
+		redisTemplate.opsForList().remove(PENDING_DEPOSIT, 1, deposit);
+		redisTemplate.opsForList().rightPush(FAILED_DEPOSIT, deposit);
+	}
+
+	@AfterThrowing(pointcut = "execution(* org.c4marathon.assignment.account.service.DepositService.failedDeposit(..))",
+		throwing = "ex")
+	public void handleFailedDepositFailure(JoinPoint joinPoint, Exception ex) {
+		Object[] args = joinPoint.getArgs();
+		String failedDeposit = (String) args[0];
+
+		String[] parts = failedDeposit.split(":");
+		Long senderAccountId = Long.valueOf(parts[1]);
+		long money = Long.parseLong(parts[3]);
+
+		accountService.rollbackWithdraw(senderAccountId, money);
+		redisTemplate.opsForList().remove(FAILED_DEPOSIT, 1, failedDeposit);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/global/aop/DepositFailureHandler.java
+++ b/src/main/java/org/c4marathon/assignment/global/aop/DepositFailureHandler.java
@@ -18,8 +18,7 @@ public class DepositFailureHandler {
 	private final RedisTemplate<String, String> redisTemplate;
 	private final AccountService accountService;
 
-	@AfterThrowing(pointcut = "execution(* org.c4marathon.assignment.account.service.DepositService.successDeposit(..))",
-		throwing = "ex")
+	@AfterThrowing(pointcut = "execution(* org.c4marathon.assignment.account.service.DepositService.successDeposit(..))", throwing = "ex")
 	public void handleDepositFailure(JoinPoint joinPoint, Exception ex) {
 
 		Object[] args = joinPoint.getArgs();
@@ -29,8 +28,7 @@ public class DepositFailureHandler {
 		redisTemplate.opsForList().rightPush(FAILED_DEPOSIT, deposit);
 	}
 
-	@AfterThrowing(pointcut = "execution(* org.c4marathon.assignment.account.service.DepositService.failedDeposit(..))",
-		throwing = "ex")
+	@AfterThrowing(pointcut = "execution(* org.c4marathon.assignment.account.service.DepositService.failedDeposit(..))", throwing = "ex")
 	public void handleFailedDepositFailure(JoinPoint joinPoint, Exception ex) {
 		Object[] args = joinPoint.getArgs();
 		String failedDeposit = (String) args[0];

--- a/src/main/java/org/c4marathon/assignment/global/config/RedisConfig.java
+++ b/src/main/java/org/c4marathon/assignment/global/config/RedisConfig.java
@@ -23,8 +23,8 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
-        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new StringRedisSerializer());

--- a/src/main/java/org/c4marathon/assignment/global/config/RedisConfig.java
+++ b/src/main/java/org/c4marathon/assignment/global/config/RedisConfig.java
@@ -1,0 +1,36 @@
+package org.c4marathon.assignment.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/org/c4marathon/assignment/global/core/MiniPayThreadPoolExecutor.java
+++ b/src/main/java/org/c4marathon/assignment/global/core/MiniPayThreadPoolExecutor.java
@@ -1,12 +1,12 @@
 package org.c4marathon.assignment.global.core;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @Slf4j

--- a/src/main/java/org/c4marathon/assignment/global/core/MiniPayThreadPoolExecutor.java
+++ b/src/main/java/org/c4marathon/assignment/global/core/MiniPayThreadPoolExecutor.java
@@ -1,0 +1,70 @@
+package org.c4marathon.assignment.global.core;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor
+@Slf4j
+public class MiniPayThreadPoolExecutor implements Executor {
+
+    private final int threadCount;
+    private final int queueSize;
+    private ThreadPoolExecutor threadPoolExecutor;
+
+    public void init() {
+        if (threadPoolExecutor != null) {
+            return;
+        }
+        threadPoolExecutor = new ThreadPoolExecutor(threadCount, threadCount, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(queueSize),
+                (r, executor) -> {
+                    try {
+                        executor.getQueue().put(r);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                });
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        if (isInvalidState()) {
+            return;
+        }
+        threadPoolExecutor.execute(() -> {
+            try {
+                command.run();
+            } catch (RuntimeException e) {
+                log.error(e.toString(), e);
+            }
+        });
+    }
+
+    public void waitToEnd() {
+        if (isInvalidState()) {
+            return;
+        }
+
+        threadPoolExecutor.shutdown();
+        while (true) {
+            try {
+                if (threadPoolExecutor.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS)) {
+                    break;
+                }
+            } catch (InterruptedException e) {
+                log.error(e.toString(), e);
+                Thread.currentThread().interrupt();
+            }
+        }
+        threadPoolExecutor = null;
+
+    }
+
+    private boolean isInvalidState() {
+        return threadPoolExecutor == null || threadPoolExecutor.isTerminating() || threadPoolExecutor.isTerminated();
+    }
+}

--- a/src/main/java/org/c4marathon/assignment/global/core/MiniPayThreadPoolExecutor.java
+++ b/src/main/java/org/c4marathon/assignment/global/core/MiniPayThreadPoolExecutor.java
@@ -12,59 +12,60 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 public class MiniPayThreadPoolExecutor implements Executor {
 
-    private final int threadCount;
-    private final int queueSize;
-    private ThreadPoolExecutor threadPoolExecutor;
+	private final int threadCount;
+	private final int queueSize;
+	private ThreadPoolExecutor threadPoolExecutor;
 
-    public void init() {
-        if (threadPoolExecutor != null) {
-            return;
-        }
-        threadPoolExecutor = new ThreadPoolExecutor(threadCount, threadCount, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(queueSize),
-                (r, executor) -> {
-                    try {
-                        executor.getQueue().put(r);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                    }
-                });
-    }
+	public void init() {
+		if (threadPoolExecutor != null) {
+			return;
+		}
+		threadPoolExecutor = new ThreadPoolExecutor(threadCount, threadCount, 0L, TimeUnit.MILLISECONDS,
+			new LinkedBlockingQueue<>(queueSize),
+			(r, executor) -> {
+				try {
+					executor.getQueue().put(r);
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
+			});
+	}
 
-    @Override
-    public void execute(Runnable command) {
-        if (isInvalidState()) {
-            return;
-        }
-        threadPoolExecutor.execute(() -> {
-            try {
-                command.run();
-            } catch (RuntimeException e) {
-                log.error(e.toString(), e);
-            }
-        });
-    }
+	@Override
+	public void execute(Runnable command) {
+		if (isInvalidState()) {
+			return;
+		}
+		threadPoolExecutor.execute(() -> {
+			try {
+				command.run();
+			} catch (RuntimeException e) {
+				log.error(e.toString(), e);
+			}
+		});
+	}
 
-    public void waitToEnd() {
-        if (isInvalidState()) {
-            return;
-        }
+	public void waitToEnd() {
+		if (isInvalidState()) {
+			return;
+		}
 
-        threadPoolExecutor.shutdown();
-        while (true) {
-            try {
-                if (threadPoolExecutor.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS)) {
-                    break;
-                }
-            } catch (InterruptedException e) {
-                log.error(e.toString(), e);
-                Thread.currentThread().interrupt();
-            }
-        }
-        threadPoolExecutor = null;
+		threadPoolExecutor.shutdown();
+		while (true) {
+			try {
+				if (threadPoolExecutor.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS)) {
+					break;
+				}
+			} catch (InterruptedException e) {
+				log.error(e.toString(), e);
+				Thread.currentThread().interrupt();
+			}
+		}
+		threadPoolExecutor = null;
 
-    }
+	}
 
-    private boolean isInvalidState() {
-        return threadPoolExecutor == null || threadPoolExecutor.isTerminating() || threadPoolExecutor.isTerminated();
-    }
+	private boolean isInvalidState() {
+		return threadPoolExecutor == null || threadPoolExecutor.isTerminating() || threadPoolExecutor.isTerminated();
+	}
 }

--- a/src/main/java/org/c4marathon/assignment/global/event/WithdrawCompletedEvent.java
+++ b/src/main/java/org/c4marathon/assignment/global/event/WithdrawCompletedEvent.java
@@ -1,0 +1,10 @@
+package org.c4marathon.assignment.global.event;
+
+public record WithdrawCompletedEvent(
+	String transactionId,
+	Long senderAccountId,
+	Long receiverAccountId,
+	long money
+) {
+
+}

--- a/src/main/java/org/c4marathon/assignment/global/event/WithdrawEventListener.java
+++ b/src/main/java/org/c4marathon/assignment/global/event/WithdrawEventListener.java
@@ -1,0 +1,30 @@
+package org.c4marathon.assignment.global.event;
+
+import static org.c4marathon.assignment.global.util.Const.*;
+
+import org.c4marathon.assignment.global.util.StringUtil;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class WithdrawEventListener {
+
+	private final RedisTemplate<String, String> redisTemplate;
+
+	@TransactionalEventListener
+	public void handleWithdrawCompleted(WithdrawCompletedEvent event) {
+		redisTemplate.opsForList().rightPush(
+			PENDING_DEPOSIT,
+			StringUtil.format("{}:{}:{}:{}",
+				event.transactionId(),
+				event.senderAccountId(),
+				event.receiverAccountId(),
+				event.money()
+			)
+		);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/global/event/deposit/DepositCompletedEvent.java
+++ b/src/main/java/org/c4marathon/assignment/global/event/deposit/DepositCompletedEvent.java
@@ -1,0 +1,4 @@
+package org.c4marathon.assignment.global.event.deposit;
+
+public record DepositCompletedEvent(String deposit) {
+}

--- a/src/main/java/org/c4marathon/assignment/global/event/deposit/DepositEventListener.java
+++ b/src/main/java/org/c4marathon/assignment/global/event/deposit/DepositEventListener.java
@@ -1,0 +1,20 @@
+package org.c4marathon.assignment.global.event.deposit;
+
+import static org.c4marathon.assignment.global.util.Const.*;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class DepositEventListener {
+	private final RedisTemplate<String, String> redisTemplate;
+
+	@TransactionalEventListener
+	public void handleDepositCompleted(DepositCompletedEvent event) {
+		redisTemplate.opsForList().remove(PENDING_DEPOSIT, 1, event.deposit());
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/global/event/member/MemberEventListener.java
+++ b/src/main/java/org/c4marathon/assignment/global/event/member/MemberEventListener.java
@@ -1,4 +1,4 @@
-package org.c4marathon.assignment.global.event;
+package org.c4marathon.assignment.global.event.member;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/org/c4marathon/assignment/global/event/member/MemberEventListener.java
+++ b/src/main/java/org/c4marathon/assignment/global/event/member/MemberEventListener.java
@@ -2,6 +2,7 @@ package org.c4marathon.assignment.global.event.member;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.c4marathon.assignment.account.service.AccountService;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Component;
 public class MemberEventListener {
 
     private final AccountService accountService;
+
     @EventListener
     public void handleMemberRegisteredEvent(MemberRegisteredEvent event) {
         accountService.createAccount(event.memberId());

--- a/src/main/java/org/c4marathon/assignment/global/event/member/MemberRegisteredEvent.java
+++ b/src/main/java/org/c4marathon/assignment/global/event/member/MemberRegisteredEvent.java
@@ -1,4 +1,4 @@
-package org.c4marathon.assignment.global.event;
+package org.c4marathon.assignment.global.event.member;
 
 public record MemberRegisteredEvent(Long memberId) {
 

--- a/src/main/java/org/c4marathon/assignment/global/event/withdraw/WithdrawCompletedEvent.java
+++ b/src/main/java/org/c4marathon/assignment/global/event/withdraw/WithdrawCompletedEvent.java
@@ -1,4 +1,4 @@
-package org.c4marathon.assignment.global.event;
+package org.c4marathon.assignment.global.event.withdraw;
 
 public record WithdrawCompletedEvent(
 	String transactionId,

--- a/src/main/java/org/c4marathon/assignment/global/event/withdraw/WithdrawEventListener.java
+++ b/src/main/java/org/c4marathon/assignment/global/event/withdraw/WithdrawEventListener.java
@@ -1,4 +1,4 @@
-package org.c4marathon.assignment.global.event;
+package org.c4marathon.assignment.global.event.withdraw;
 
 import static org.c4marathon.assignment.global.util.Const.*;
 

--- a/src/main/java/org/c4marathon/assignment/global/util/Const.java
+++ b/src/main/java/org/c4marathon/assignment/global/util/Const.java
@@ -8,4 +8,7 @@ public class Const {
     public static final long CHARGE_LIMIT = 3_000_000L;
     public static final long DEFAULT_BALANCE = 0L;
     public static final long CHARGE_AMOUNT = 10_000L;
+    public static final long MAX_RETRIES = 3;
+
+
 }

--- a/src/main/java/org/c4marathon/assignment/global/util/Const.java
+++ b/src/main/java/org/c4marathon/assignment/global/util/Const.java
@@ -7,4 +7,5 @@ import lombok.NoArgsConstructor;
 public class Const {
     public static final long CHARGE_LIMIT = 3_000_000L;
     public static final long DEFAULT_BALANCE = 0L;
+    public static final long CHARGE_AMOUNT = 10_000L;
 }

--- a/src/main/java/org/c4marathon/assignment/global/util/Const.java
+++ b/src/main/java/org/c4marathon/assignment/global/util/Const.java
@@ -9,6 +9,8 @@ public class Const {
     public static final long DEFAULT_BALANCE = 0L;
     public static final long CHARGE_AMOUNT = 10_000L;
     public static final long MAX_RETRIES = 3;
+    public static final String PENDING_DEPOSIT = "pending-deposit";
+    public static final String FAILED_DEPOSIT = "failed-deposit";
 
 
 }

--- a/src/main/java/org/c4marathon/assignment/member/service/MemberService.java
+++ b/src/main/java/org/c4marathon/assignment/member/service/MemberService.java
@@ -9,7 +9,7 @@ import org.c4marathon.assignment.member.dto.MemberRegisterResponse;
 import org.c4marathon.assignment.member.exception.DuplicateEmailException;
 import org.c4marathon.assignment.member.exception.InvalidPasswordException;
 import org.c4marathon.assignment.member.exception.NotFoundMemberException;
-import org.c4marathon.assignment.global.event.MemberRegisteredEvent;
+import org.c4marathon.assignment.global.event.member.MemberRegisteredEvent;
 import org.c4marathon.assignment.global.session.SessionMemberInfo;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;

--- a/src/main/java/org/c4marathon/assignment/member/service/MemberService.java
+++ b/src/main/java/org/c4marathon/assignment/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package org.c4marathon.assignment.member.service;
 
 import lombok.RequiredArgsConstructor;
+
 import org.c4marathon.assignment.member.domain.Member;
 import org.c4marathon.assignment.member.dto.MemberLoginRequest;
 import org.c4marathon.assignment.member.dto.MemberRegisterRequest;
@@ -19,50 +20,50 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class MemberService {
-    private final MemberRepository memberRepository;
-    private final PasswordEncoder passwordEncoder;
-    private final ApplicationEventPublisher eventPublisher;
+	private final MemberRepository memberRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final ApplicationEventPublisher eventPublisher;
 
-    @Transactional
-    public MemberRegisterResponse register(MemberRegisterRequest request) {
+	@Transactional
+	public MemberRegisterResponse register(MemberRegisterRequest request) {
 
-        if (validateEmailDuplicate(request.email())) {
-            throw new DuplicateEmailException();
-        }
+		if (validateEmailDuplicate(request.email())) {
+			throw new DuplicateEmailException();
+		}
 
-        String encodedPassword = passwordEncoder.encode(request.password());
+		String encodedPassword = passwordEncoder.encode(request.password());
 
-        Member member = Member.create(
-                request.email(),
-                request.name(),
-                encodedPassword
-        );
+		Member member = Member.create(
+			request.email(),
+			request.name(),
+			encodedPassword
+		);
 
-        memberRepository.save(member);
-        eventPublisher.publishEvent(new MemberRegisteredEvent(member.getId()));
+		memberRepository.save(member);
+		eventPublisher.publishEvent(new MemberRegisteredEvent(member.getId()));
 
-        return new MemberRegisterResponse(member.getId(), member.getEmail());
-    }
+		return new MemberRegisterResponse(member.getId(), member.getEmail());
+	}
 
-    @Transactional
-    public SessionMemberInfo login(MemberLoginRequest request) {
-        Member member = memberRepository.findByEmail(request.email())
-                .orElseThrow(NotFoundMemberException::new);
+	@Transactional
+	public SessionMemberInfo login(MemberLoginRequest request) {
+		Member member = memberRepository.findByEmail(request.email())
+			.orElseThrow(NotFoundMemberException::new);
 
-        if (!passwordMatches(request.password(), member.getPassword())) {
-            throw new InvalidPasswordException();
-        }
+		if (!passwordMatches(request.password(), member.getPassword())) {
+			throw new InvalidPasswordException();
+		}
 
-        return new SessionMemberInfo(member.getId(), member.getEmail(), member.getAccountId());
+		return new SessionMemberInfo(member.getId(), member.getEmail(), member.getAccountId());
 
-    }
+	}
 
-    private boolean passwordMatches(String loginPassword, String matchPassword) {
-        return passwordEncoder.matches(loginPassword, matchPassword);
-    }
+	private boolean passwordMatches(String loginPassword, String matchPassword) {
+		return passwordEncoder.matches(loginPassword, matchPassword);
+	}
 
-    private boolean validateEmailDuplicate(String email) {
-        return memberRepository.existsByEmail(email);
+	private boolean validateEmailDuplicate(String email) {
+		return memberRepository.existsByEmail(email);
 
-    }
+	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,13 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
 
+    data:
+      redis:
+        host: ${REDIS_HOST}
+        port: ${REDIS_PORT}
+
+
+
 ---
 spring:
   config:
@@ -32,6 +39,10 @@ spring:
         format_sql: true
     defer-datasource-initialization: true # (2.5~) Hibernate ??? ?? data.sql ??
 
+    data:
+      redis:
+        host: ${REDIS_HOST}
+        port: ${REDIS_PORT}
 ---
 spring:
   config:
@@ -52,6 +63,11 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.H2Dialect
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
   h2:
     console:
       enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,7 +50,7 @@ spring:
       on-profile: test
 
   datasource:
-    url: jdbc:h2:mem:testdb
+    url: jdbc:h2:mem:testdb;DB_CLOSE_ON_EXIT=FALSE
     driver-class-name: org.h2.Driver
     username: sa
     password:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,6 +67,9 @@ spring:
     redis:
       port: 6379
       host: localhost
+      lettuce:
+        pool:
+          enabled: false
 
   h2:
     console:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,8 +65,8 @@ spring:
         dialect: org.hibernate.dialect.H2Dialect
   data:
     redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
+      host: localhost
+      port: 6379
 
   h2:
     console:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,8 +19,8 @@ spring:
 
   data:
     redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
+      port: 6379
+      host: localhost
 
 
 
@@ -41,8 +41,8 @@ spring:
 
   data:
     redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
+      port: 6379
+      host: localhost
 ---
 spring:
   config:
@@ -65,8 +65,8 @@ spring:
         dialect: org.hibernate.dialect.H2Dialect
   data:
     redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
+      port: 6379
+      host: localhost
 
   h2:
     console:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,10 +17,10 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
 
-    data:
-      redis:
-        host: ${REDIS_HOST}
-        port: ${REDIS_PORT}
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
 
 
@@ -39,10 +39,10 @@ spring:
         format_sql: true
     defer-datasource-initialization: true # (2.5~) Hibernate ??? ?? data.sql ??
 
-    data:
-      redis:
-        host: ${REDIS_HOST}
-        port: ${REDIS_PORT}
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 ---
 spring:
   config:
@@ -65,8 +65,8 @@ spring:
         dialect: org.hibernate.dialect.H2Dialect
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
   h2:
     console:

--- a/src/test/java/org/c4marathon/assignment/account/domain/AccountTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/domain/AccountTest.java
@@ -10,7 +10,7 @@ class AccountTest {
 
 	@DisplayName("입금이 성공한다")
 	@Test
-	void deposit() throws Exception {
+	void deposit() {
 	    // given
 		Account account = Account.create(10000L);
 
@@ -22,7 +22,7 @@ class AccountTest {
 	}
 	@DisplayName("출금이 성공한다.")
 	@Test
-	void withdraw() throws Exception {
+	void withdraw() {
 		// given
 		Account account = Account.create(10000L);
 

--- a/src/test/java/org/c4marathon/assignment/account/domain/AccountTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/domain/AccountTest.java
@@ -1,0 +1,94 @@
+package org.c4marathon.assignment.account.domain;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.c4marathon.assignment.global.util.Const.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AccountTest {
+
+	@DisplayName("입금이 성공한다")
+	@Test
+	void deposit() throws Exception {
+	    // given
+		Account account = Account.create(10000L);
+
+		// when
+		account.deposit(10000L);
+
+		// then
+		assertThat(account.getMoney()).isEqualTo(20000L);
+	}
+	@DisplayName("출금이 성공한다.")
+	@Test
+	void withdraw() throws Exception {
+		// given
+		Account account = Account.create(10000L);
+
+		// when
+		account.withdraw(10000L);
+
+		// then
+		assertThat(account.getMoney()).isZero();
+	}
+
+	@DisplayName("일일 충전 한도를 초과하면 false를 반환한다.")
+	@Test
+	void chargeLimitExceeded() {
+		// given
+		Account account = Account.create(10000L);
+		long exceedAmount = CHARGE_LIMIT + 1;
+
+		// when
+		boolean result = account.isChargeWithinDailyLimit(exceedAmount);
+
+		// then
+		assertThat(result).isFalse();
+		assertThat(account.getChargeLimit()).isEqualTo(CHARGE_LIMIT); // 차감되지 않음
+	}
+
+	@DisplayName("일일 충전 한도 내에서 충전하면 true를 반환하고 한도가 차감된다.")
+	@Test
+	void chargeWithinLimit() {
+		// given
+		Account account = Account.create(10000L);
+		long chargeAmount = 5_000L;
+
+		// when
+		boolean result = account.isChargeWithinDailyLimit(chargeAmount);
+
+		// then
+		assertThat(result).isTrue();
+		assertThat(account.getChargeLimit()).isEqualTo(CHARGE_LIMIT - chargeAmount);
+	}
+
+	@DisplayName("잔액이 부족하면 송금할 수 없다.")
+	@Test
+	void insufficientBalanceForSend() {
+		// given
+		Account account = Account.create(10000L);
+		long sendAmount = 20_000L; // 잔액보다 큰 금액
+
+		// when
+		boolean result = account.isSend(sendAmount);
+
+		// then
+		assertThat(result).isFalse();
+	}
+
+	@DisplayName("잔액이 충분하면 송금할 수 있다.")
+	@Test
+	void sufficientBalanceForSend() {
+		// given
+		Account account = Account.create(10000L);
+		long sendAmount = 5_000L;
+
+		// when
+		boolean result = account.isSend(sendAmount);
+
+		// then
+		assertThat(result).isTrue();
+	}
+
+}

--- a/src/test/java/org/c4marathon/assignment/account/domain/repository/AccountRepositoryTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/domain/repository/AccountRepositoryTest.java
@@ -1,0 +1,38 @@
+package org.c4marathon.assignment.account.domain.repository;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.c4marathon.assignment.global.util.Const.*;
+
+import java.util.Optional;
+
+import org.c4marathon.assignment.IntegrationTestSupport;
+import org.c4marathon.assignment.account.domain.Account;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+class AccountRepositoryTest extends IntegrationTestSupport {
+
+	@Autowired
+	private AccountRepository accountRepository;
+
+	@DisplayName("Account Id를 통해 Account를 조회한다. ")
+	@Test
+	@Transactional
+	void findAccountByAccountId() throws Exception {
+	    // given
+		Account account = Account.create(DEFAULT_BALANCE);
+		accountRepository.save(account);
+
+	    // when
+		Optional<Account> findAccount = accountRepository.findByIdWithLock(account.getId());
+
+		// then
+
+		assertThat(findAccount.get())
+			.extracting("money", "chargeLimit")
+			.contains(0L, CHARGE_LIMIT);
+	}
+}

--- a/src/test/java/org/c4marathon/assignment/account/presentation/AccountControllerTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/presentation/AccountControllerTest.java
@@ -1,6 +1,10 @@
 package org.c4marathon.assignment.account.presentation;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
 import org.c4marathon.assignment.ControllerTestSupport;
+import org.c4marathon.assignment.account.dto.WithdrawRequest;
 import org.c4marathon.assignment.global.session.SessionConst;
 import org.c4marathon.assignment.global.session.SessionMemberInfo;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,10 +13,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 class AccountControllerTest extends ControllerTestSupport {
+
     @BeforeEach
     void initSession() {
         session = new MockHttpSession();
@@ -40,8 +42,10 @@ class AccountControllerTest extends ControllerTestSupport {
     @DisplayName("money가 음수일 경우 예외가 발생한다.")
     @Test
     void chargeWithInvalidMoney() throws Exception {
+        // given
         long invalidMoney = -500L;
 
+        // when // then
         mockMvc.perform(
                         post("/api/charge")
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -50,4 +54,37 @@ class AccountControllerTest extends ControllerTestSupport {
                 )
                 .andExpect(status().isBadRequest());
     }
+
+    @DisplayName("다른 메인 계좌로 송금 성공")
+    @Test
+    void withdraw() throws Exception {
+        // given
+        WithdrawRequest request = new WithdrawRequest(1L, 5000L);
+
+        // when // then
+        mockMvc.perform(
+                post("/api/withdraw")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+                    .session(session)
+            )
+            .andExpect(status().isOk());
+    }
+
+    @DisplayName("출금 금액이 음수일 경우 예외가 발생한다.")
+    @Test
+    void withdrawWithNegativeAmount() throws Exception {
+        // given
+        WithdrawRequest request = new WithdrawRequest(2L, -5000L); // 음수 금액
+
+        // when // then
+        mockMvc.perform(
+                post("/api/withdraw")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+                    .session(session)
+            )
+            .andExpect(status().isBadRequest());
+    }
+
 }

--- a/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
@@ -12,7 +12,7 @@ import org.c4marathon.assignment.account.domain.repository.SavingAccountReposito
 import org.c4marathon.assignment.account.dto.WithdrawRequest;
 import org.c4marathon.assignment.account.exception.DailyChargeLimitExceededException;
 import org.c4marathon.assignment.account.exception.NotFoundAccountException;
-import org.c4marathon.assignment.global.event.WithdrawCompletedEvent;
+import org.c4marathon.assignment.global.event.withdraw.WithdrawCompletedEvent;
 import org.c4marathon.assignment.member.domain.Member;
 import org.c4marathon.assignment.member.domain.repository.MemberRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -25,7 +25,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.transaction.support.TransactionTemplate;
 
 @ExtendWith(MockitoExtension.class)
 class AccountServiceTest extends IntegrationTestSupport {

--- a/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
@@ -202,7 +202,7 @@ class AccountServiceTest extends IntegrationTestSupport {
         // then
         Account updatedSenderAccount = accountRepository.findById(senderAccount.getId())
                 .orElseThrow(NotFoundAccountException::new);
-        assertThat(updatedSenderAccount.getMoney()).isEqualTo(0L);
+        assertThat(updatedSenderAccount.getMoney()).isZero();
 
         verify(listOperations).rightPush(
                 eq(PENDING_DEPOSIT),

--- a/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
@@ -24,7 +24,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.c4marathon.assignment.global.util.Const.DEFAULT_BALANCE;
+import static org.c4marathon.assignment.global.util.Const.*;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.when;
 
@@ -182,7 +182,7 @@ class AccountServiceTest extends IntegrationTestSupport {
         assertThat(updatedSenderAccount.getMoney()).isEqualTo(30000L);
 
         verify(listOperations).rightPush(
-                eq("pending-deposits"),
+                eq(PENDING_DEPOSIT),
                 matches(".*:" + senderAccount.getId() + ":2:20000")
         );
     }
@@ -205,20 +205,21 @@ class AccountServiceTest extends IntegrationTestSupport {
         assertThat(updatedSenderAccount.getMoney()).isEqualTo(0L);
 
         verify(listOperations).rightPush(
-                eq("pending-deposits"),
+                eq(PENDING_DEPOSIT),
                 matches(".*:" + senderAccount.getId() + ":2:200000")
         );
     }
 
     @DisplayName("송금 시 잔액이 부족해 충전할 때 일일 한도를 초과하면 예외가 발생한다.")
     @Test
-    void withdrawWithDailyChargeLimit() throws Exception {
+    void withdrawWithDailyChargeLimit() {
         // given
         Account senderAccount = createAccount(5000L);
         WithdrawRequest request = new WithdrawRequest(2L, 3_500_000L);
 
         // when // then
-        assertThatThrownBy(() -> accountService.withdraw(senderAccount.getId(), request))
+        Long senderAccountId = senderAccount.getId();
+        assertThatThrownBy(() -> accountService.withdraw(senderAccountId, request))
                 .isInstanceOf(DailyChargeLimitExceededException.class);
     }
 

--- a/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
@@ -51,8 +51,7 @@ class AccountServiceTest extends IntegrationTestSupport {
     @Test
     void createAccount() throws Exception {
         // given
-        Member member = Member.create("test@test.com", "테스트", "testPassword");
-        memberRepository.save(member);
+        Member member = createMember();
 
         // when
         accountService.createAccount(member.getId());
@@ -64,12 +63,12 @@ class AccountServiceTest extends IntegrationTestSupport {
         Account account = accountRepository.findById(updatedMember.getAccountId()).orElseThrow();
         assertThat(account).isNotNull();
     }
+
     @DisplayName("메인 계좌에 돈을 충전한다.")
     @Test
     void chargeMoney() throws Exception {
         // given
-        Account account =Account.create(DEFAULT_BALANCE);
-        accountRepository.save(account);
+        Account account = createAccount(DEFAULT_BALANCE);
 
         long chargeAmount = 50_000L;
 
@@ -86,8 +85,7 @@ class AccountServiceTest extends IntegrationTestSupport {
     @Test
     void chargeMoneyWithDailyLimitExceeded() throws Exception {
         // given
-        Account account = Account.create(DEFAULT_BALANCE);
-        accountRepository.save(account);
+        Account account = createAccount(DEFAULT_BALANCE);
 
         long chargeAmount = 3_500_000L;
 
@@ -101,8 +99,7 @@ class AccountServiceTest extends IntegrationTestSupport {
     @Test
     void sendToSavingAccount() throws Exception {
         // given
-        Member member = Member.create("test@test.com", "테스트", "testPassword");
-        memberRepository.save(member);
+        Member member = createMember();
 
         Account account = Account.create(10000L);
         member.setMainAccountId(account.getId());
@@ -128,8 +125,7 @@ class AccountServiceTest extends IntegrationTestSupport {
     @Test
     void sendToSavingAccountWithInsufficientBalance() throws Exception {
         // given
-        Member member = Member.create("test@test.com", "테스트", "testPassword");
-        memberRepository.save(member);
+        Member member = createMember();
 
         Account account = Account.create(12000L);
         member.setMainAccountId(account.getId());
@@ -158,8 +154,7 @@ class AccountServiceTest extends IntegrationTestSupport {
     @Test
     void withdraw() throws Exception {
         // given
-        Account senderAccount = Account.create(50000L);
-        accountRepository.save(senderAccount);
+        Account senderAccount = createAccount(50000L);
 
         WithdrawRequest request = new WithdrawRequest(2L, 20000L);
 
@@ -182,8 +177,7 @@ class AccountServiceTest extends IntegrationTestSupport {
     @Test
     void withdrawWithInsufficientBalance() throws Exception {
         // given
-        Account senderAccount = Account.create(50000L);
-        accountRepository.save(senderAccount);
+        Account senderAccount = createAccount(50000L);
 
         WithdrawRequest request = new WithdrawRequest(2L, 200000L);
 
@@ -207,14 +201,25 @@ class AccountServiceTest extends IntegrationTestSupport {
     @Test
     void withdrawWithDailyChargeLimit() throws Exception {
         // given
-        Account senderAccount = Account.create(5000L);
-        accountRepository.save(senderAccount);
+        Account senderAccount = createAccount(5000L);
 
         WithdrawRequest request = new WithdrawRequest(2L, 3_500_000L);
 
         // when // then
         assertThatThrownBy(() -> accountService.withdraw(senderAccount.getId(), request))
                 .isInstanceOf(DailyChargeLimitExceededException.class);
+    }
+
+    private Account createAccount(long money) {
+        Account senderAccount = Account.create(money);
+        accountRepository.save(senderAccount);
+        return senderAccount;
+    }
+
+    private Member createMember() {
+        Member member = Member.create("test@test.com", "테스트", "testPassword");
+        memberRepository.save(member);
+        return member;
     }
 
 }

--- a/src/test/java/org/c4marathon/assignment/account/service/DepositServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/DepositServiceTest.java
@@ -185,7 +185,7 @@ class DepositServiceTest {
 
 	@DisplayName("Redis에 입금 대기 데이터가 없는 경우, 입금 처리를 하지 않는다.")
 	@Test
-	void deposits_ShouldNotProcess_WhenNoPendingDepositsExist() throws Exception {
+	void deposits_ShouldNotProcess_WhenNoPendingDepositsExist() {
 
 		// given
 		given(listOperations.range(PENDING_DEPOSIT, 0, -1)).willReturn(List.of());
@@ -210,13 +210,13 @@ class DepositServiceTest {
 		depositService.deposits();
 
 		// then
-		verify(listOperations).remove(eq(PENDING_DEPOSIT), eq(1L), eq(deposit));
+		verify(listOperations).remove(PENDING_DEPOSIT, 1L, deposit);
 		verify(listOperations).rightPush(FAILED_DEPOSIT, deposit);
 	}
 
 	@DisplayName("실패한 입금들은 재시도를 한다.")
 	@Test
-	void rollbackDeposits_RetrySuccess() throws Exception {
+	void rollbackDeposits_RetrySuccess() {
 		// given
 		String failedDeposit = "tx1:1:2:1000";
 		given(listOperations.range(FAILED_DEPOSIT, 0, -1))
@@ -230,14 +230,14 @@ class DepositServiceTest {
 		depositService.rollbackDeposits();
 
 		// then
-		verify(listOperations).remove(eq(FAILED_DEPOSIT), eq(1L), eq(failedDeposit));
+		verify(listOperations).remove(FAILED_DEPOSIT, 1L, failedDeposit);
 		verify(receiverAccount).deposit(1000);
 		verify(accountRepository).save(receiverAccount);
 	}
 
 	@DisplayName("최대 재시도 횟수 초과 시 출금을 롤백 한다.")
 	@Test
-	void rollbackDeposits_ExceedMaxRetries() throws Exception {
+	void rollbackDeposits_ExceedMaxRetries() {
 
 		// given
 		String failedDeposit = "tx1:1:2:1000";
@@ -257,7 +257,7 @@ class DepositServiceTest {
 		// when
 		depositService.rollbackDeposits();
 		// then
-		verify(listOperations).remove(eq(FAILED_DEPOSIT), eq(1L), eq(failedDeposit));
+		verify(listOperations).remove(FAILED_DEPOSIT, 1L, failedDeposit);
 		verify(redisTemplate).delete("deposit-failures:tx1");
 		verify(senderAccount).deposit(1000);
 		verify(accountRepository).save(senderAccount);

--- a/src/test/java/org/c4marathon/assignment/account/service/DepositServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/DepositServiceTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -30,6 +29,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.c4marathon.assignment.global.util.Const.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -37,232 +37,229 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class DepositServiceTest {
 
-    @Mock
-    private AccountRepository accountRepository;
+	@Mock
+	private AccountRepository accountRepository;
 
-    @Mock
-    private RedisTemplate<String, String> redisTemplate;
+	@Mock
+	private RedisTemplate<String, String> redisTemplate;
 
-    @Mock
-    private ListOperations<String, String> listOperations;
+	@Mock
+	private ListOperations<String, String> listOperations;
 
-    @Mock
-    private ValueOperations<String, String> valueOperations;
+	@Mock
+	private ValueOperations<String, String> valueOperations;
 
-    @Spy
-    private MiniPayThreadPoolExecutor threadPoolExecutor = new MiniPayThreadPoolExecutor(8, 32);
-    private DepositService depositService;
+	@Spy
+	private MiniPayThreadPoolExecutor threadPoolExecutor = new MiniPayThreadPoolExecutor(8, 32);
+	private DepositService depositService;
 
-    @BeforeEach
-    void setUp() {
-        depositService = new DepositService(accountRepository, redisTemplate);
-        ReflectionTestUtils.setField(depositService, "threadPoolExecutor", threadPoolExecutor);
-        when(redisTemplate.opsForList()).thenReturn(listOperations);
-    }
+	@BeforeEach
+	void setUp() {
+		depositService = new DepositService(accountRepository, redisTemplate);
+		ReflectionTestUtils.setField(depositService, "threadPoolExecutor", threadPoolExecutor);
+		when(redisTemplate.opsForList()).thenReturn(listOperations);
+	}
 
-    @DisplayName("ThreadPool이 초기화되고 모든 태스크가 병렬로 처리되는지 검증")
-    @Test
-    void depositsWithMultiThread() throws Exception {
-        // given
-        int numberOfDeposits = 16;
-        CountDownLatch processLatch = new CountDownLatch(numberOfDeposits);
-        AtomicInteger concurrentExecutions = new AtomicInteger(0);
-        AtomicInteger maxConcurrentExecutions = new AtomicInteger(0);
+	@DisplayName("ThreadPool이 초기화되고 모든 태스크가 병렬로 처리되는지 검증")
+	@Test
+	void depositsWithMultiThread() throws Exception {
+		// given
+		int numberOfDeposits = 16;
+		CountDownLatch processLatch = new CountDownLatch(numberOfDeposits);
+		AtomicInteger concurrentExecutions = new AtomicInteger(0);
+		AtomicInteger maxConcurrentExecutions = new AtomicInteger(0);
 
-        List<String> deposits = new ArrayList<>();
-        for (int i = 0; i < numberOfDeposits; i++) {
-            deposits.add(StringUtil.format("tx{}:{}:{}:{}", i, i + 1L, i + 2L, 1000));
-        }
-        given(listOperations.range("pending-deposits", 0, -1)).willReturn(deposits);
+		List<String> deposits = new ArrayList<>();
+		for (int i = 0; i < numberOfDeposits; i++) {
+			deposits.add(StringUtil.format("tx{}:{}:{}:{}", i, i + 1L, i + 2L, 1000));
+		}
+		given(listOperations.range(PENDING_DEPOSIT, 0, -1)).willReturn(deposits);
 
-        for (int i = 0; i < numberOfDeposits; i++) {
-            Account account = mock(Account.class);
-            given(accountRepository.findByIdWithLock(i + 2L)).willReturn(Optional.of(account));
+		for (int i = 0; i < numberOfDeposits; i++) {
+			Account account = mock(Account.class);
+			given(accountRepository.findByIdWithLock(i + 2L)).willReturn(Optional.of(account));
 
-            doAnswer(invocation -> {
-                int current = concurrentExecutions.incrementAndGet();
-                maxConcurrentExecutions.updateAndGet(max -> Math.max(max, current));
-                Thread.sleep(100);
-                concurrentExecutions.decrementAndGet();
-                processLatch.countDown();
-                return null;
-            }).when(account).deposit(anyLong());
-        }
+			doAnswer(invocation -> {
+				int current = concurrentExecutions.incrementAndGet();
+				maxConcurrentExecutions.updateAndGet(max -> Math.max(max, current));
+				Thread.sleep(100);
+				concurrentExecutions.decrementAndGet();
+				processLatch.countDown();
+				return null;
+			}).when(account).deposit(anyLong());
+		}
 
-        // When
-        long startTime = System.currentTimeMillis();
-        depositService.deposits();
-        boolean allProcessed = processLatch.await(5, TimeUnit.SECONDS);
+		// When
+		long startTime = System.currentTimeMillis();
+		depositService.deposits();
+		boolean allProcessed = processLatch.await(5, TimeUnit.SECONDS);
 
-        // Then
-        assertThat(allProcessed).isTrue();
-        assertThat(maxConcurrentExecutions.get()).isEqualTo(8); // threadCount
-        long executionTime = System.currentTimeMillis() - startTime;
-        // 순차 처리였다면 16 * 100ms = 1600ms 걸렸을 것
-        assertThat(executionTime).isLessThan(1000L);
-    }
+		// Then
+		assertThat(allProcessed).isTrue();
+		assertThat(maxConcurrentExecutions.get()).isEqualTo(8); // threadCount
+		long executionTime = System.currentTimeMillis() - startTime;
+		// 순차 처리였다면 16 * 100ms = 1600ms 걸렸을 것
+		assertThat(executionTime).isLessThan(1000L);
+	}
 
-    @DisplayName("같은 계좌에 동시에 입금 요청이 와도 동시성 문제 없이 정확한 금액이 입금된다.")
-    @Test
-    void deposits_ConcurrencyTest() throws Exception {
+	@DisplayName("같은 계좌에 동시에 입금 요청이 와도 동시성 문제 없이 정확한 금액이 입금된다.")
+	@Test
+	void deposits_ConcurrencyTest() throws Exception {
 
-        // given
-        int numberOfDeposits = 100;
-        CountDownLatch processLatch = new CountDownLatch(numberOfDeposits);
+		// given
+		int numberOfDeposits = 100;
+		CountDownLatch processLatch = new CountDownLatch(numberOfDeposits);
 
-        long expectedTotalAmount = IntStream.range(0, numberOfDeposits)
-                .mapToLong(i -> 100L * i)
-                .sum();
+		long expectedTotalAmount = IntStream.range(0, numberOfDeposits)
+			.mapToLong(i -> 100L * i)
+			.sum();
 
-        AtomicLong actualTotalAmount = new AtomicLong(0);
+		AtomicLong actualTotalAmount = new AtomicLong(0);
 
-        ConcurrentHashMap<Long, AtomicInteger> accountDepositCounts = new ConcurrentHashMap<>();
-        ConcurrentHashMap<Long, AtomicLong> accountDepositAmounts = new ConcurrentHashMap<>();
+		ConcurrentHashMap<Long, AtomicInteger> accountDepositCounts = new ConcurrentHashMap<>();
+		ConcurrentHashMap<Long, AtomicLong> accountDepositAmounts = new ConcurrentHashMap<>();
 
-        // 같은 계좌에 대한 여러 입금 요청 생성
-        List<String> deposits = IntStream.range(0, numberOfDeposits)
-                .mapToObj(i -> StringUtil.format("tx{}:{}:{}:{}", i, i + 3L, 2L, 100 * i))
-                .toList();
+		// 같은 계좌에 대한 여러 입금 요청 생성
+		List<String> deposits = IntStream.range(0, numberOfDeposits)
+			.mapToObj(i -> StringUtil.format("tx{}:{}:{}:{}", i, i + 3L, 2L, 100 * i))
+			.toList();
 
-        given(listOperations.range("pending-deposits", 0, -1))
-                .willReturn(deposits);
+		given(listOperations.range(PENDING_DEPOSIT, 0, -1))
+			.willReturn(deposits);
 
-        Account account = mock(Account.class);
-        given(accountRepository.findByIdWithLock(2L))
-                .willReturn(Optional.of(account));
+		Account account = mock(Account.class);
+		given(accountRepository.findByIdWithLock(2L))
+			.willReturn(Optional.of(account));
 
-        // 동시성 및 정확성 검증을 위한 모킹
-        doAnswer(invocation -> {
-            long amount = invocation.getArgument(0);
-            accountDepositCounts.computeIfAbsent(2L, k -> new AtomicInteger(0)).incrementAndGet(); // 동시 실행 계수 추적
-            actualTotalAmount.addAndGet(amount); // 실제 입금 총액 추적
-            accountDepositAmounts.computeIfAbsent(2L, k -> new AtomicLong(0)).addAndGet(amount); // 계좌별 입금 금액 추적
-            Thread.sleep(10); // 입금 시뮬레이션을 위한 작은 지연
-            processLatch.countDown();
-            return null;
-        }).when(account).deposit(anyLong());
+		// 동시성 및 정확성 검증을 위한 모킹
+		doAnswer(invocation -> {
+			long amount = invocation.getArgument(0);
+			accountDepositCounts.computeIfAbsent(2L, k -> new AtomicInteger(0)).incrementAndGet(); // 동시 실행 계수 추적
+			actualTotalAmount.addAndGet(amount); // 실제 입금 총액 추적
+			accountDepositAmounts.computeIfAbsent(2L, k -> new AtomicLong(0)).addAndGet(amount); // 계좌별 입금 금액 추적
+			Thread.sleep(10); // 입금 시뮬레이션을 위한 작은 지연
+			processLatch.countDown();
+			return null;
+		}).when(account).deposit(anyLong());
 
-        // when
-        depositService.deposits();
-        boolean allProcessed = processLatch.await(5, TimeUnit.SECONDS);
+		// when
+		depositService.deposits();
+		boolean allProcessed = processLatch.await(5, TimeUnit.SECONDS);
 
-        // then
-        assertThat(allProcessed).isTrue(); // 모든 입금 요청이 처리되었는지 검증
-        assertThat(accountDepositCounts.get(2L).get()).isEqualTo(numberOfDeposits); // 입금 횟수 검증
-        assertThat(actualTotalAmount.get()).isEqualTo(expectedTotalAmount); // 총 입금 금액 검증
-    }
+		// then
+		assertThat(allProcessed).isTrue(); // 모든 입금 요청이 처리되었는지 검증
+		assertThat(accountDepositCounts.get(2L).get()).isEqualTo(numberOfDeposits); // 입금 횟수 검증
+		assertThat(actualTotalAmount.get()).isEqualTo(expectedTotalAmount); // 총 입금 금액 검증
+	}
 
+	@DisplayName("Redis에 입금 대기 데이터가 존재할 경우, 모든 입금 요청을 처리하고 Redis에서 삭제한다.")
+	@Test
+	void deposit_Success() {
+		// given
+		List<String> deposits = List.of(
+			"tx1:1:2:1000",
+			"tx2:2:3:3000",
+			"tx3:3:4:4000"
+		);
+		given(listOperations.range(PENDING_DEPOSIT, 0, -1)).willReturn(deposits);
 
+		Account account1 = mock(Account.class);
+		Account account2 = mock(Account.class);
+		Account account3 = mock(Account.class);
 
-    @DisplayName("Redis에 입금 대기 데이터가 존재할 경우, 모든 입금 요청을 처리하고 Redis에서 삭제한다.")
-    @Test
-    void deposit_Success() throws Exception {
-        // given
-        List<String> deposits = List.of(
-                "tx1:1:2:1000",
-                "tx2:2:3:3000",
-                "tx3:3:4:4000"
-        );
-        given(listOperations.range("pending-deposits", 0, -1)).willReturn(deposits);
+		given(accountRepository.findByIdWithLock(2L)).willReturn(Optional.of(account1));
+		given(accountRepository.findByIdWithLock(3L)).willReturn(Optional.of(account2));
+		given(accountRepository.findByIdWithLock(4L)).willReturn(Optional.of(account3));
 
-        Account account1 = mock(Account.class);
-        Account account2 = mock(Account.class);
-        Account account3 = mock(Account.class);
+		// when
+		depositService.deposits();
 
-        given(accountRepository.findByIdWithLock(2L)).willReturn(Optional.of(account1));
-        given(accountRepository.findByIdWithLock(3L)).willReturn(Optional.of(account2));
-        given(accountRepository.findByIdWithLock(4L)).willReturn(Optional.of(account3));
+		// then
+		verify(listOperations, times(3)).remove(eq(PENDING_DEPOSIT), anyLong(), anyString());
+		verify(accountRepository, times(3)).save(any(Account.class));
 
-        // when
-        depositService.deposits();
+		verify(account1).deposit(1000);
+		verify(account2).deposit(3000);
+		verify(account3).deposit(4000);
+	}
 
-        // then
-        verify(listOperations, times(3)).remove(eq("pending-deposits"), anyLong(), anyString());
-        verify(accountRepository, times(3)).save(any(Account.class));
+	@DisplayName("Redis에 입금 대기 데이터가 없는 경우, 입금 처리를 하지 않는다.")
+	@Test
+	void deposits_ShouldNotProcess_WhenNoPendingDepositsExist() throws Exception {
 
-        verify(account1).deposit(1000);
-        verify(account2).deposit(3000);
-        verify(account3).deposit(4000);
-    }
+		// given
+		given(listOperations.range(PENDING_DEPOSIT, 0, -1)).willReturn(List.of());
 
+		// when
+		depositService.deposits();
 
-    @DisplayName("Redis에 입금 대기 데이터가 없는 경우, 입금 처리를 하지 않는다.")
-    @Test
-    void deposits_ShouldNotProcess_WhenNoPendingDepositsExist() throws Exception {
+		// then
+		verify(listOperations, times(1)).range(PENDING_DEPOSIT, 0, -1);
+		verify(listOperations, never()).remove(eq(PENDING_DEPOSIT), anyLong(), anyString());
+	}
 
-        // given
-        given(listOperations.range("pending-deposits", 0, -1)).willReturn(List.of());
+	@DisplayName("입금 실패 시 failed-deposits로 데이터가 저장된다.")
+	@Test
+	void deposits_Failure() {
+		// given
+		String deposit = "tx1:1:2:1000";
+		given(listOperations.range(PENDING_DEPOSIT, 0, -1)).willReturn(List.of(deposit));
+		given(accountRepository.findByIdWithLock(2L)).willThrow(new NotFoundAccountException());
 
-        // when
-        depositService.deposits();
+		// when
+		depositService.deposits();
 
-        // then
-        verify(listOperations, times(1)).range("pending-deposits", 0, -1);
-        verify(listOperations, never()).remove(eq("pending-deposits"), anyLong(), anyString());
-    }
+		// then
+		verify(listOperations).remove(eq(PENDING_DEPOSIT), eq(1L), eq(deposit));
+		verify(listOperations).rightPush(FAILED_DEPOSIT, deposit);
+	}
 
-    @DisplayName("입금 실패 시 failed-deposits로 데이터가 저장된다.")
-    @Test
-    void deposits_Failure() throws Exception {
-        // given
-        String deposit = "tx1:1:2:1000";
-        given(listOperations.range("pending-deposits", 0, -1)).willReturn(List.of(deposit));
-        given(accountRepository.findByIdWithLock(2L)).willThrow(new NotFoundAccountException());
+	@DisplayName("실패한 입금들은 재시도를 한다.")
+	@Test
+	void rollbackDeposits_RetrySuccess() throws Exception {
+		// given
+		String failedDeposit = "tx1:1:2:1000";
+		given(listOperations.range(FAILED_DEPOSIT, 0, -1))
+			.willReturn(List.of(failedDeposit));
 
-        // when
-        depositService.deposits();
+		Account receiverAccount = mock(Account.class);
+		given(accountRepository.findByIdWithLock(2L))
+			.willReturn(Optional.of(receiverAccount));
 
-        // then
-        verify(listOperations).remove(eq("pending-deposits"), eq(1L), eq(deposit));
-        verify(listOperations).rightPush("failed-deposits", deposit);
-    }
+		// when
+		depositService.rollbackDeposits();
 
-    @DisplayName("실패한 입금들은 재시도를 한다.")
-    @Test
-    void rollbackDeposits_RetrySuccess() throws Exception {
-        // given
-        String failedDeposit = "tx1:1:2:1000";
-        given(listOperations.range("failed-deposits", 0, -1))
-                .willReturn(List.of(failedDeposit));
+		// then
+		verify(listOperations).remove(eq(FAILED_DEPOSIT), eq(1L), eq(failedDeposit));
+		verify(receiverAccount).deposit(1000);
+		verify(accountRepository).save(receiverAccount);
+	}
 
-        Account receiverAccount = mock(Account.class);
-        given(accountRepository.findByIdWithLock(2L))
-                .willReturn(Optional.of(receiverAccount));
+	@DisplayName("최대 재시도 횟수 초과 시 출금을 롤백 한다.")
+	@Test
+	void rollbackDeposits_ExceedMaxRetries() throws Exception {
 
-        // when
-        depositService.rollbackDeposits();
+		// given
+		String failedDeposit = "tx1:1:2:1000";
+		given(listOperations.range(FAILED_DEPOSIT, 0, -1))
+			.willReturn(List.of(failedDeposit));
 
-        // then
-        verify(listOperations).remove(eq("failed-deposits"), eq(1L), eq(failedDeposit));
-        verify(receiverAccount).deposit(1000);
-        verify(accountRepository).save(receiverAccount);
-    }
+		given(accountRepository.findByIdWithLock(2L))
+			.willThrow(new NotFoundAccountException());
 
-    @DisplayName("최대 재시도 횟수 초과 시 출금을 롤백 한다.")
-    @Test
-    void rollbackDeposits_ExceedMaxRetries() throws Exception {
+		given(redisTemplate.opsForValue()).willReturn(valueOperations);
+		given(valueOperations.increment("deposit-failures:tx1"))
+			.willReturn(6L);
 
-        // given
-        String failedDeposit = "tx1:1:2:1000";
-        given(listOperations.range("failed-deposits", 0, -1))
-                .willReturn(List.of(failedDeposit));
-
-        given(accountRepository.findByIdWithLock(2L))
-                .willThrow(new NotFoundAccountException());
-
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
-        given(valueOperations.increment("deposit-failures:tx1"))
-                .willReturn(6L);
-
-        Account senderAccount = mock(Account.class);
-        given(accountRepository.findByIdWithLock(1L))
-                .willReturn(Optional.of(senderAccount));
-        // when
-        depositService.rollbackDeposits();
-        // then
-        verify(listOperations).remove(eq("failed-deposits"), eq(1L), eq(failedDeposit));
-        verify(redisTemplate).delete("deposit-failures:tx1");
-        verify(senderAccount).deposit(1000);
-        verify(accountRepository).save(senderAccount);
-    }
+		Account senderAccount = mock(Account.class);
+		given(accountRepository.findByIdWithLock(1L))
+			.willReturn(Optional.of(senderAccount));
+		// when
+		depositService.rollbackDeposits();
+		// then
+		verify(listOperations).remove(eq(FAILED_DEPOSIT), eq(1L), eq(failedDeposit));
+		verify(redisTemplate).delete("deposit-failures:tx1");
+		verify(senderAccount).deposit(1000);
+		verify(accountRepository).save(senderAccount);
+	}
 }

--- a/src/test/java/org/c4marathon/assignment/account/service/DepositServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/DepositServiceTest.java
@@ -1,0 +1,159 @@
+package org.c4marathon.assignment.account.service;
+
+import org.c4marathon.assignment.account.domain.Account;
+import org.c4marathon.assignment.account.domain.repository.AccountRepository;
+import org.c4marathon.assignment.account.exception.NotFoundAccountException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class DepositServiceTest {
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ListOperations<String, String> listOperations;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    private DepositService depositService;
+
+    @BeforeEach
+    void setUp() {
+        when(redisTemplate.opsForList()).thenReturn(listOperations);
+    }
+
+    @DisplayName("Redis에 입금 대기 데이터가 존재할 경우, 모든 입금 요청을 처리하고 Redis에서 삭제한다.")
+    @Test
+    void deposit_Success() throws Exception {
+        // given
+        List<String> deposits = List.of(
+                "tx1:1:2:1000",
+                "tx2:2:3:3000",
+                "tx3:3:4:4000"
+        );
+        given(listOperations.range("pending-deposits", 0, -1)).willReturn(deposits);
+
+        Account account1 = mock(Account.class);
+        Account account2 = mock(Account.class);
+        Account account3 = mock(Account.class);
+
+        given(accountRepository.findByIdWithLock(2L)).willReturn(Optional.of(account1));
+        given(accountRepository.findByIdWithLock(3L)).willReturn(Optional.of(account2));
+        given(accountRepository.findByIdWithLock(4L)).willReturn(Optional.of(account3));
+
+        // when
+        depositService.deposits();
+
+        // then
+        verify(listOperations, times(3)).remove(eq("pending-deposits"), anyLong(), anyString());
+        verify(accountRepository, times(3)).save(any(Account.class));
+
+        verify(account1).deposit(1000);
+        verify(account2).deposit(3000);
+        verify(account3).deposit(4000);
+    }
+
+
+    @DisplayName("Redis에 입금 대기 데이터가 없는 경우, 입금 처리를 하지 않는다.")
+    @Test
+    void deposits_ShouldNotProcess_WhenNoPendingDepositsExist() throws Exception {
+
+        // given
+        given(listOperations.range("pending-deposits", 0, -1)).willReturn(List.of());
+
+        // when
+        depositService.deposits();
+
+        // then
+        verify(listOperations, times(1)).range("pending-deposits", 0, -1);
+        verify(listOperations, never()).remove(eq("pending-deposits"), anyLong(), anyString());
+    }
+
+    @DisplayName("입금 실패 시 failed-deposits로 데이터가 저장된다.")
+    @Test
+    void deposits_Failure() throws Exception {
+        // given
+        String deposit = "tx1:1:2:1000";
+        given(listOperations.range("pending-deposits", 0, -1)).willReturn(List.of(deposit));
+        given(accountRepository.findByIdWithLock(2L)).willThrow(new NotFoundAccountException());
+
+        // when
+        depositService.deposits();
+
+        // then
+        verify(listOperations).remove(eq("pending-deposits"), eq(1L), eq(deposit));
+        verify(listOperations).rightPush("failed-deposits", deposit);
+    }
+
+    @DisplayName("실패한 입금들은 재시도를 한다.")
+    @Test
+    void rollbackDeposits_RetrySuccess() throws Exception {
+        // given
+        String failedDeposit = "tx1:1:2:1000";
+        given(listOperations.range("failed-deposits", 0, -1))
+                .willReturn(List.of(failedDeposit));
+
+        Account receiverAccount = mock(Account.class);
+        given(accountRepository.findByIdWithLock(2L))
+                .willReturn(Optional.of(receiverAccount));
+
+        // when
+        depositService.rollbackDeposits();
+
+        // then
+        verify(listOperations).remove(eq("failed-deposits"), eq(1L), eq(failedDeposit));
+        verify(receiverAccount).deposit(1000);
+        verify(accountRepository).save(receiverAccount);
+    }
+
+    @DisplayName("최대 재시도 횟수 초과 시 출금을 롤백 한다.")
+    @Test
+    void rollbackDeposits_ExceedMaxRetries() throws Exception {
+
+        // given
+        String failedDeposit = "tx1:1:2:1000";
+        given(listOperations.range("failed-deposits", 0, -1))
+                .willReturn(List.of(failedDeposit));
+
+        given(accountRepository.findByIdWithLock(2L))
+                .willThrow(new NotFoundAccountException());
+
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.increment("deposit-failures:tx1"))
+                .willReturn(6L);
+
+        Account senderAccount = mock(Account.class);
+        given(accountRepository.findByIdWithLock(1L))
+                .willReturn(Optional.of(senderAccount));
+        // when
+        depositService.rollbackDeposits();
+        // then
+        verify(listOperations).remove(eq("failed-deposits"), eq(1L), eq(failedDeposit));
+        verify(redisTemplate).delete("deposit-failures:tx1");
+        verify(senderAccount).deposit(1000);
+        verify(accountRepository).save(senderAccount);
+    }
+}

--- a/src/test/java/org/c4marathon/assignment/account/service/DepositServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/DepositServiceTest.java
@@ -1,265 +1,71 @@
 package org.c4marathon.assignment.account.service;
 
+import static org.assertj.core.api.Assertions.*;
+
+import org.c4marathon.assignment.IntegrationTestSupport;
 import org.c4marathon.assignment.account.domain.Account;
 import org.c4marathon.assignment.account.domain.repository.AccountRepository;
 import org.c4marathon.assignment.account.exception.NotFoundAccountException;
-import org.c4marathon.assignment.global.core.MiniPayThreadPoolExecutor;
 import org.c4marathon.assignment.global.util.StringUtil;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.Spy;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.redis.core.ListOperations;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.IntStream;
+class DepositServiceTest extends IntegrationTestSupport {
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.c4marathon.assignment.global.util.Const.*;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
-
-@ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
-class DepositServiceTest {
-
-	@Mock
+	@Autowired
 	private AccountRepository accountRepository;
 
-	@Mock
-	private RedisTemplate<String, String> redisTemplate;
-
-	@Mock
-	private ListOperations<String, String> listOperations;
-
-	@Mock
-	private ValueOperations<String, String> valueOperations;
-
-	@Spy
-	private MiniPayThreadPoolExecutor threadPoolExecutor = new MiniPayThreadPoolExecutor(8, 32);
+	@Autowired
 	private DepositService depositService;
 
-	@BeforeEach
-	void setUp() {
-		depositService = new DepositService(accountRepository, redisTemplate);
-		ReflectionTestUtils.setField(depositService, "threadPoolExecutor", threadPoolExecutor);
-		when(redisTemplate.opsForList()).thenReturn(listOperations);
+	@AfterEach
+	void tearDown() {
+		accountRepository.deleteAllInBatch();
 	}
 
-	@DisplayName("ThreadPool이 초기화되고 모든 태스크가 병렬로 처리되는지 검증")
+	@DisplayName("입금이 성공한다.")
 	@Test
-	void depositsWithMultiThread() throws Exception {
+	void successDeposit() {
 		// given
-		int numberOfDeposits = 16;
-		CountDownLatch processLatch = new CountDownLatch(numberOfDeposits);
-		AtomicInteger concurrentExecutions = new AtomicInteger(0);
-		AtomicInteger maxConcurrentExecutions = new AtomicInteger(0);
+		Account senderAccount = createAccount(10000L);
+		Account receiverAccount = createAccount(20000L);
 
-		List<String> deposits = new ArrayList<>();
-		for (int i = 0; i < numberOfDeposits; i++) {
-			deposits.add(StringUtil.format("tx{}:{}:{}:{}", i, i + 1L, i + 2L, 1000));
-		}
-		given(listOperations.range(PENDING_DEPOSIT, 0, -1)).willReturn(deposits);
-
-		for (int i = 0; i < numberOfDeposits; i++) {
-			Account account = mock(Account.class);
-			given(accountRepository.findByIdWithLock(i + 2L)).willReturn(Optional.of(account));
-
-			doAnswer(invocation -> {
-				int current = concurrentExecutions.incrementAndGet();
-				maxConcurrentExecutions.updateAndGet(max -> Math.max(max, current));
-				Thread.sleep(100);
-				concurrentExecutions.decrementAndGet();
-				processLatch.countDown();
-				return null;
-			}).when(account).deposit(anyLong());
-		}
-
-		// When
-		long startTime = System.currentTimeMillis();
-		depositService.deposits();
-		boolean allProcessed = processLatch.await(5, TimeUnit.SECONDS);
-
-		// Then
-		assertThat(allProcessed).isTrue();
-		assertThat(maxConcurrentExecutions.get()).isEqualTo(8); // threadCount
-		long executionTime = System.currentTimeMillis() - startTime;
-		// 순차 처리였다면 16 * 100ms = 1600ms 걸렸을 것
-		assertThat(executionTime).isLessThan(1000L);
-	}
-
-	@DisplayName("같은 계좌에 동시에 입금 요청이 와도 동시성 문제 없이 정확한 금액이 입금된다.")
-	@Test
-	void deposits_ConcurrencyTest() throws Exception {
-
-		// given
-		int numberOfDeposits = 100;
-		CountDownLatch processLatch = new CountDownLatch(numberOfDeposits);
-
-		long expectedTotalAmount = IntStream.range(0, numberOfDeposits)
-			.mapToLong(i -> 100L * i)
-			.sum();
-
-		AtomicLong actualTotalAmount = new AtomicLong(0);
-
-		ConcurrentHashMap<Long, AtomicInteger> accountDepositCounts = new ConcurrentHashMap<>();
-		ConcurrentHashMap<Long, AtomicLong> accountDepositAmounts = new ConcurrentHashMap<>();
-
-		// 같은 계좌에 대한 여러 입금 요청 생성
-		List<String> deposits = IntStream.range(0, numberOfDeposits)
-			.mapToObj(i -> StringUtil.format("tx{}:{}:{}:{}", i, i + 3L, 2L, 100 * i))
-			.toList();
-
-		given(listOperations.range(PENDING_DEPOSIT, 0, -1))
-			.willReturn(deposits);
-
-		Account account = mock(Account.class);
-		given(accountRepository.findByIdWithLock(2L))
-			.willReturn(Optional.of(account));
-
-		// 동시성 및 정확성 검증을 위한 모킹
-		doAnswer(invocation -> {
-			long amount = invocation.getArgument(0);
-			accountDepositCounts.computeIfAbsent(2L, k -> new AtomicInteger(0)).incrementAndGet(); // 동시 실행 계수 추적
-			actualTotalAmount.addAndGet(amount); // 실제 입금 총액 추적
-			accountDepositAmounts.computeIfAbsent(2L, k -> new AtomicLong(0)).addAndGet(amount); // 계좌별 입금 금액 추적
-			Thread.sleep(10); // 입금 시뮬레이션을 위한 작은 지연
-			processLatch.countDown();
-			return null;
-		}).when(account).deposit(anyLong());
+		String deposit = StringUtil.format("{}:{}:{}:{}", "tx1", senderAccount.getId(), receiverAccount.getId(), 1000L);
 
 		// when
-		depositService.deposits();
-		boolean allProcessed = processLatch.await(5, TimeUnit.SECONDS);
+		depositService.successDeposit(deposit);
 
 		// then
-		assertThat(allProcessed).isTrue(); // 모든 입금 요청이 처리되었는지 검증
-		assertThat(accountDepositCounts.get(2L).get()).isEqualTo(numberOfDeposits); // 입금 횟수 검증
-		assertThat(actualTotalAmount.get()).isEqualTo(expectedTotalAmount); // 총 입금 금액 검증
+		Account updatedReceiverAccount = accountRepository.findById(receiverAccount.getId())
+			.orElseThrow(NotFoundAccountException::new);
+
+		assertThat(updatedReceiverAccount.getMoney()).isEqualTo(21000L);
 	}
 
-	@DisplayName("Redis에 입금 대기 데이터가 존재할 경우, 모든 입금 요청을 처리하고 Redis에서 삭제한다.")
+
+	@DisplayName("입금 재시도를 성공한다.")
 	@Test
-	void deposit_Success() {
+	void failedDeposit() {
 		// given
-		List<String> deposits = List.of(
-			"tx1:1:2:1000",
-			"tx2:2:3:3000",
-			"tx3:3:4:4000"
-		);
-		given(listOperations.range(PENDING_DEPOSIT, 0, -1)).willReturn(deposits);
+		Account senderAccount = createAccount(10000L);
+		Account receiverAccount = createAccount(20000L);
 
-		Account account1 = mock(Account.class);
-		Account account2 = mock(Account.class);
-		Account account3 = mock(Account.class);
-
-		given(accountRepository.findByIdWithLock(2L)).willReturn(Optional.of(account1));
-		given(accountRepository.findByIdWithLock(3L)).willReturn(Optional.of(account2));
-		given(accountRepository.findByIdWithLock(4L)).willReturn(Optional.of(account3));
+		String deposit = StringUtil.format("{}:{}:{}:{}", "tx1", senderAccount.getId(), receiverAccount.getId(), 1000L);
 
 		// when
-		depositService.deposits();
+		depositService.failedDeposit(deposit);
 
 		// then
-		verify(listOperations, times(3)).remove(eq(PENDING_DEPOSIT), anyLong(), anyString());
-		verify(accountRepository, times(3)).save(any(Account.class));
+		Account updatedReceiverAccount = accountRepository.findById(receiverAccount.getId())
+			.orElseThrow(NotFoundAccountException::new);
 
-		verify(account1).deposit(1000);
-		verify(account2).deposit(3000);
-		verify(account3).deposit(4000);
+		assertThat(updatedReceiverAccount.getMoney()).isEqualTo(21000L);
 	}
-
-	@DisplayName("Redis에 입금 대기 데이터가 없는 경우, 입금 처리를 하지 않는다.")
-	@Test
-	void deposits_ShouldNotProcess_WhenNoPendingDepositsExist() {
-
-		// given
-		given(listOperations.range(PENDING_DEPOSIT, 0, -1)).willReturn(List.of());
-
-		// when
-		depositService.deposits();
-
-		// then
-		verify(listOperations, times(1)).range(PENDING_DEPOSIT, 0, -1);
-		verify(listOperations, never()).remove(eq(PENDING_DEPOSIT), anyLong(), anyString());
-	}
-
-	@DisplayName("입금 실패 시 failed-deposits로 데이터가 저장된다.")
-	@Test
-	void deposits_Failure() {
-		// given
-		String deposit = "tx1:1:2:1000";
-		given(listOperations.range(PENDING_DEPOSIT, 0, -1)).willReturn(List.of(deposit));
-		given(accountRepository.findByIdWithLock(2L)).willThrow(new NotFoundAccountException());
-
-		// when
-		depositService.deposits();
-
-		// then
-		verify(listOperations).remove(PENDING_DEPOSIT, 1L, deposit);
-		verify(listOperations).rightPush(FAILED_DEPOSIT, deposit);
-	}
-
-	@DisplayName("실패한 입금들은 재시도를 한다.")
-	@Test
-	void rollbackDeposits_RetrySuccess() {
-		// given
-		String failedDeposit = "tx1:1:2:1000";
-		given(listOperations.range(FAILED_DEPOSIT, 0, -1))
-			.willReturn(List.of(failedDeposit));
-
-		Account receiverAccount = mock(Account.class);
-		given(accountRepository.findByIdWithLock(2L))
-			.willReturn(Optional.of(receiverAccount));
-
-		// when
-		depositService.rollbackDeposits();
-
-		// then
-		verify(listOperations).remove(FAILED_DEPOSIT, 1L, failedDeposit);
-		verify(receiverAccount).deposit(1000);
-		verify(accountRepository).save(receiverAccount);
-	}
-
-	@DisplayName("최대 재시도 횟수 초과 시 출금을 롤백 한다.")
-	@Test
-	void rollbackDeposits_ExceedMaxRetries() {
-
-		// given
-		String failedDeposit = "tx1:1:2:1000";
-		given(listOperations.range(FAILED_DEPOSIT, 0, -1))
-			.willReturn(List.of(failedDeposit));
-
-		given(accountRepository.findByIdWithLock(2L))
-			.willThrow(new NotFoundAccountException());
-
-		given(redisTemplate.opsForValue()).willReturn(valueOperations);
-		given(valueOperations.increment("deposit-failures:tx1"))
-			.willReturn(6L);
-
-		Account senderAccount = mock(Account.class);
-		given(accountRepository.findByIdWithLock(1L))
-			.willReturn(Optional.of(senderAccount));
-		// when
-		depositService.rollbackDeposits();
-		// then
-		verify(listOperations).remove(FAILED_DEPOSIT, 1L, failedDeposit);
-		verify(redisTemplate).delete("deposit-failures:tx1");
-		verify(senderAccount).deposit(1000);
-		verify(accountRepository).save(senderAccount);
+	private Account createAccount(long money) {
+		Account account = Account.create(money);
+		accountRepository.save(account);
+		return account;
 	}
 }

--- a/src/test/java/org/c4marathon/assignment/account/service/scheduler/DepositSchedulerTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/scheduler/DepositSchedulerTest.java
@@ -125,7 +125,7 @@ class DepositSchedulerTest {
 
 	@DisplayName("PENDING_DEPOSIT에서 데이터를 가져와 successDeposit이 호출된다.")
 	@Test
-	void deposits() throws Exception {
+	void deposits() {
 	    // given
 		List<String> pendingDeposits = List.of(
 			"tx1:1:2:1000",

--- a/src/test/java/org/c4marathon/assignment/account/service/scheduler/DepositSchedulerTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/scheduler/DepositSchedulerTest.java
@@ -1,0 +1,184 @@
+package org.c4marathon.assignment.account.service.scheduler;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.c4marathon.assignment.global.util.Const.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
+
+import org.c4marathon.assignment.account.service.DepositService;
+import org.c4marathon.assignment.global.core.MiniPayThreadPoolExecutor;
+import org.c4marathon.assignment.global.util.StringUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class DepositSchedulerTest {
+
+	@Mock
+	private DepositService depositService;
+
+	@Mock
+	private RedisTemplate<String, String> redisTemplate;
+
+	@Mock
+	private ListOperations<String, String> listOperations;
+
+	@InjectMocks
+	private DepositScheduler depositScheduler;
+
+	private MiniPayThreadPoolExecutor threadPoolExecutor = new MiniPayThreadPoolExecutor(8, 32);
+
+	@BeforeEach
+	void setUp() {
+		when(redisTemplate.opsForList()).thenReturn(listOperations);
+		ReflectionTestUtils.setField(depositScheduler, "threadPoolExecutor", threadPoolExecutor);
+	}
+
+	@DisplayName("ThreadPool이 초기화되고 모든 태스크가 병렬로 처리되는지 검증")
+	@Test
+	void depositsParallelExecution() throws Exception {
+	    // given
+		int numberOfDeposits = 16;
+		CountDownLatch processLatch = new CountDownLatch(numberOfDeposits);
+		AtomicInteger concurrentExecutions = new AtomicInteger(0);
+		AtomicInteger maxConcurrentExecutions = new AtomicInteger(0);
+
+		List<String> deposits = new ArrayList<>();
+		for (int i = 0; i < numberOfDeposits; i++) {
+			deposits.add(StringUtil.format("tx{}:{}:{}:{}", i, i + 1L, i + 2L, 1000));
+		}
+		given(listOperations.range(PENDING_DEPOSIT, 0, -1)).willReturn(deposits);
+
+		doAnswer(invocation -> {
+			int current = concurrentExecutions.incrementAndGet();
+			maxConcurrentExecutions.updateAndGet(max -> Math.max(max, current));
+			Thread.sleep(100);
+			concurrentExecutions.decrementAndGet();
+			processLatch.countDown();
+			return null;
+		}).when(depositService).successDeposit(anyString());
+
+	    // when
+		long startTime = System.currentTimeMillis();
+		depositScheduler.deposits();
+		boolean allProcessed = processLatch.await(5, TimeUnit.SECONDS);
+
+		// then
+		assertThat(allProcessed).isTrue();
+		assertThat(maxConcurrentExecutions.get()).isEqualTo(8);
+		long executionTime = System.currentTimeMillis() - startTime;
+		assertThat(executionTime).isLessThan(1000L);
+	}
+
+	@DisplayName("같은 계좌에 동시에 입금 요청이 와도 동시성 문제 없이 정확한 금액이 입금된다.")
+	@Test
+	void depositsConcurrency() throws Exception {
+	    // given
+		int numberOfDeposits = 100;
+		CountDownLatch processLatch = new CountDownLatch(numberOfDeposits);
+		long expectedTotalAmount = IntStream.range(0, numberOfDeposits)
+			.mapToLong(i -> 100L * i)
+			.sum();
+
+		AtomicLong actualTotalAmount = new AtomicLong(0);
+
+		List<String> deposits = IntStream.range(0, numberOfDeposits)
+			.mapToObj(i -> StringUtil.format("tx{}:{}:{}:{}", i, i + 3L, 2L, 100 * i))
+			.toList();
+		given(listOperations.range(PENDING_DEPOSIT, 0, -1)).willReturn(deposits);
+
+		doAnswer(invocation -> {
+			String deposit = invocation.getArgument(0);
+			long amount = Long.parseLong(deposit.split(":")[3]);
+			actualTotalAmount.addAndGet(amount);
+			Thread.sleep(10);
+			processLatch.countDown();
+			return null;
+		}).when(depositService).successDeposit(anyString());
+
+		// when
+		depositScheduler.deposits();
+		boolean allProcessed = processLatch.await(5, TimeUnit.SECONDS);
+
+		// then
+		assertThat(allProcessed).isTrue();
+		assertThat(actualTotalAmount.get()).isEqualTo(expectedTotalAmount);
+		verify(depositService, times(numberOfDeposits)).successDeposit(anyString());
+	}
+
+	@DisplayName("PENDING_DEPOSIT에서 데이터를 가져와 successDeposit이 호출된다.")
+	@Test
+	void deposits() throws Exception {
+	    // given
+		List<String> pendingDeposits = List.of(
+			"tx1:1:2:1000",
+			"tx2:3:4:2000"
+		);
+		when(listOperations.range(PENDING_DEPOSIT, 0, -1)).thenReturn(pendingDeposits);
+
+		// when
+		depositScheduler.deposits();
+
+	    // then
+		verify(depositService, times(1)).successDeposit("tx1:1:2:1000");
+		verify(depositService, times(1)).successDeposit("tx2:3:4:2000");
+	}
+
+	@DisplayName("PENDING_DEPOSIT에 데이터가 없으면 successDeposit이 호출되지 않는다.")
+	@Test
+	void deposits_emptyList() {
+		// given
+		when(listOperations.range(PENDING_DEPOSIT, 0, -1)).thenReturn(List.of());
+
+		// when
+		depositScheduler.deposits();
+
+		// then
+		verify(depositService, never()).successDeposit(any());
+	}
+
+	@DisplayName("FAILED_DEPOSIT에서 데이터를 가져와 failedDeposit이 호출된다.")
+	@Test
+	void rollbackDeposits() {
+		// given
+		List<String> failedDeposits = List.of("tx3:5:6:500", "tx4:7:8:1500");
+		when(listOperations.range(FAILED_DEPOSIT, 0, -1)).thenReturn(failedDeposits);
+
+		// when
+		depositScheduler.rollbackDeposits();
+
+		// then
+		verify(depositService, times(1)).failedDeposit("tx3:5:6:500");
+		verify(depositService, times(1)).failedDeposit("tx4:7:8:1500");
+	}
+
+	@DisplayName("FAILED_DEPOSIT에 데이터가 없으면 failedDeposit이 호출되지 않는다.")
+	@Test
+	void rollbackDeposits_emptyList() {
+		// given
+		when(listOperations.range(FAILED_DEPOSIT, 0, -1)).thenReturn(List.of());
+
+		// when
+		depositScheduler.rollbackDeposits();
+
+		// then
+		verify(depositService, never()).failedDeposit(any());
+	}
+}

--- a/src/test/java/org/c4marathon/assignment/global/aop/DepositFailureHandlerTest.java
+++ b/src/test/java/org/c4marathon/assignment/global/aop/DepositFailureHandlerTest.java
@@ -42,7 +42,7 @@ class DepositFailureHandlerTest {
 
 	@DisplayName("successDeposit에서 예외 발생 시 Redis List PENDING_DEPOSIT을 제거되고, FAILED_DEPOSIT에 추가된다. ")
 	@Test
-	void handleDepositFailure() throws Exception {
+	void handleDepositFailure() {
 
 		// given
 		String deposit = "tx1:1:2:1000";

--- a/src/test/java/org/c4marathon/assignment/global/aop/DepositFailureHandlerTest.java
+++ b/src/test/java/org/c4marathon/assignment/global/aop/DepositFailureHandlerTest.java
@@ -1,0 +1,86 @@
+package org.c4marathon.assignment.global.aop;
+
+import static org.c4marathon.assignment.global.util.Const.*;
+import static org.mockito.Mockito.*;
+
+import org.aspectj.lang.JoinPoint;
+import org.c4marathon.assignment.account.service.AccountService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class DepositFailureHandlerTest {
+
+	@Mock
+	private RedisTemplate<String, String> redisTemplate;
+
+	@Mock
+	private ListOperations<String, String> listOperations;
+
+	@Mock
+	private AccountService accountService;
+
+	@Mock
+	private JoinPoint joinPoint;
+
+	@InjectMocks
+	private DepositFailureHandler depositFailureHandler;
+
+	@BeforeEach
+	void setUp() {
+		when(redisTemplate.opsForList()).thenReturn(listOperations);
+	}
+
+	@DisplayName("successDeposit에서 예외 발생 시 Redis List PENDING_DEPOSIT을 제거되고, FAILED_DEPOSIT에 추가된다. ")
+	@Test
+	void handleDepositFailure() throws Exception {
+
+		// given
+		String deposit = "tx1:1:2:1000";
+		when(joinPoint.getArgs()).thenReturn(new Object[] {deposit});
+		// when
+		depositFailureHandler.handleDepositFailure(joinPoint, new RuntimeException("예외 발생"));
+
+		// then
+
+		verify(listOperations, times(1)).remove(PENDING_DEPOSIT, 1, deposit);
+		verify(listOperations, times(1)).rightPush(FAILED_DEPOSIT, deposit);
+	}
+
+	@DisplayName("failedDeposit에서 예외 발생 시 rollbackWithdraw가 호출된다.")
+	@Test
+	void handleFailedDepositFailure_callsRollbackWithdraw() {
+		// given
+		String failedDeposit = "tx2:1:2:1000";
+		when(joinPoint.getArgs()).thenReturn(new Object[] {failedDeposit});
+
+		// when
+		depositFailureHandler.handleFailedDepositFailure(joinPoint, new RuntimeException("예외 발생"));
+
+		// then
+		verify(accountService, times(1)).rollbackWithdraw(1L, 1000L);
+	}
+
+	@DisplayName("failedDeposit에서 예외 발생 시 FAILED_DEPOSIT 리스트에서 삭제된다.")
+	@Test
+	void handleFailedDepositFailure_removesFromFailedDepositList() {
+		// given
+		String failedDeposit = "tx3:1:2:1000";
+		when(joinPoint.getArgs()).thenReturn(new Object[] {failedDeposit});
+
+		// when
+		depositFailureHandler.handleFailedDepositFailure(joinPoint, new RuntimeException("예외 발생"));
+
+		// then
+		verify(listOperations, times(1)).remove(FAILED_DEPOSIT, 1, failedDeposit);
+	}
+}

--- a/src/test/java/org/c4marathon/assignment/global/event/deposit/DepositEventListenerTest.java
+++ b/src/test/java/org/c4marathon/assignment/global/event/deposit/DepositEventListenerTest.java
@@ -1,0 +1,42 @@
+package org.c4marathon.assignment.global.event.deposit;
+
+import static org.mockito.BDDMockito.*;
+
+import org.c4marathon.assignment.global.util.Const;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ListOperations;
+
+@ExtendWith(MockitoExtension.class)
+class DepositEventListenerTest {
+
+	@Mock
+	private RedisTemplate<String, String> redisTemplate;
+
+	@Mock
+	private ListOperations<String, String> listOperations;
+
+	@InjectMocks
+	private DepositEventListener depositEventListener;
+
+	@DisplayName("입금 완료 이벤트가 발생하면 PENDING_DEPOSIT 리스트에서 해당 항목이 삭제된다.")
+	@Test
+	void handleDepositCompleted() {
+		// given
+		String depositInfo = "tx1:1:2:5000";
+		DepositCompletedEvent event = new DepositCompletedEvent(depositInfo);
+
+		given(redisTemplate.opsForList()).willReturn(listOperations);
+
+		// when
+		depositEventListener.handleDepositCompleted(event);
+
+		// then
+		verify(listOperations, times(1)).remove(Const.PENDING_DEPOSIT, 1, depositInfo);
+	}
+}

--- a/src/test/java/org/c4marathon/assignment/global/event/withdraw/WithdrawEventListenerTest.java
+++ b/src/test/java/org/c4marathon/assignment/global/event/withdraw/WithdrawEventListenerTest.java
@@ -1,0 +1,55 @@
+package org.c4marathon.assignment.global.event.withdraw;
+
+import static org.c4marathon.assignment.global.util.Const.*;
+import static org.mockito.BDDMockito.*;
+
+import org.c4marathon.assignment.global.util.StringUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class WithdrawEventListenerTest {
+
+	@Mock
+	private RedisTemplate<String, String> redisTemplate;
+
+	@Mock
+	private ListOperations<String, String> listOperations;
+
+	@InjectMocks
+	private WithdrawEventListener withdrawEventListener;
+
+	@DisplayName("출금 완료 이벤트가 발생하면 PENDING_DEPOSIT 리스트에 해당 항목이 추가된다.")
+	@Test
+	void handleWithdrawCompleted() {
+		// given
+		String transactionId = "tx123";
+		Long senderAccountId = 1L;
+		Long receiverAccountId = 2L;
+		long money = 5000L;
+
+		WithdrawCompletedEvent event = new WithdrawCompletedEvent(transactionId, senderAccountId, receiverAccountId, money);
+
+		given(redisTemplate.opsForList()).willReturn(listOperations);
+
+		// when
+		withdrawEventListener.handleWithdrawCompleted(event);
+
+		// then
+		verify(listOperations, times(1)).rightPush(
+			PENDING_DEPOSIT,
+			StringUtil.format("{}:{}:{}:{}",
+				transactionId,
+				senderAccountId,
+				receiverAccountId,
+				money
+			)
+		);
+	}
+}


### PR DESCRIPTION
# 메인 계좌(A) -> 메인 계좌(B) 송금
- 메인 계좌 A에서의 출금 시 걸리는 락을 메인 계좌 B에 입금 작업이 끝날 때까지 가지고 가기 때문에 락의 범위를 줄이기 위해 분리했습니다.
  - 트랜잭션 분리를 위해 메시지 큐를 찾아봤으나 현재 프로젝트의 서버가 한 대를 바탕으로 진행하고 있기 때문에 메시지 큐를 사용하는 것보다 Redis의 List 자료구조를 사용했습니다.
- 송금 요청 시 출금을 하고 커밋을 완료 후 Redis List에 출금 내용을 저장하는 이벤트를 발행합니다.
  - @TransactionalEventListener를 사용해서 출금 트랜잭션이 커밋이 된 후에 이벤트가 실행되도록 했습니다.

- 입금 트랜잭션의 경우 스케줄러를 돌면서 Redis List에 저장되어 있는 출금 기록을 통해 입금을 수행합니다.
- 입금 로직의 경우 멀티 스레드를 사용해 병렬 처리를 합니다.
- 입금 성공 시 Redis List에 출금 내용을 삭제하는 이벤트를 발행한다.
- 입금 실패 시 AOP를 통해 재시도를 위한 Redis List에 저장 한다.
    - 재시도도 실패 시 출금 롤백을 시도한다.

# 송금 시 잔액 부족 시 10,000원 단위로 충전 후 송금
송금 시 과정
- 현재 내 잔액에 돈이 충분한지 확인하고 일일 한도를 초과하는 금액이 아닌지 확인
- 충분하다면 송금
- 부족하다면 부족한 금액을 10,000원 단위로 계산 후 충전할 금액이 일일 한도를 초과하는지 확인 후 송금

# 한도 유효기간 관리
- Step 1 기존 로직을 유지했습니다.
- 인당 한도가 달라지는 기능이 추가되거나 한도 초기화 주기가 바뀌는 상황이 있을 때를 대비하기 위해서 변경하기 좋은 구조를 고려해야할 것 같습니다.

입금 하는 과정에서 실패하는 경우 재시도를 시도하고 재시도도 실패하면 출금을 복구하는 과정으로 구현했는데, 출금을 복구하는 과정에 보상 트랜잭션에서 또 문제가 있을 경우 보상 트랜잭션에 대한 보상 트랜잭션을 구현해야 되는 것인지 고민이 됩니다. 이럴 경우 어떻게 하나요?