### PR TITLE
Feature/hellozo0 step4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 
     //test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    //mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 checkstyle {

--- a/src/main/java/org/c4marathon/assignment/common/QueryExecuteTemplate.java
+++ b/src/main/java/org/c4marathon/assignment/common/QueryExecuteTemplate.java
@@ -1,0 +1,50 @@
+package org.c4marathon.assignment.common;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class QueryExecuteTemplate {
+
+	/**
+	 * Cursor Paging 을 적용하여 select 를 수행한 후, 조회된 결과로 비즈니스 로직을 수행한다.
+	 */
+	public static <T> void selectAndExecuteWithCursor(int limit, Function<T, List<T>> selectFunction,
+		Consumer<List<T>> resultConsumer) {
+		List<T> resultList = null;
+		do {
+			resultList = selectFunction.apply(resultList != null ? resultList.get(resultList.size() - 1) : null);
+			if (!resultList.isEmpty()) {
+				resultConsumer.accept(resultList);
+			}
+		} while (resultList.size() >= limit);
+	}
+
+	/**
+	 * Cursor Paging 을 적용하여 select 를 수행한 후, 조회된 결과로 비즈니스 로직을 수행한다.
+	 * 단, iteration 횟수가 pageLimit 에 도달한 경우 중단한다.
+	 */
+	public static <T> void selectAndExecuteWithCursorAndPageLimit(int pageLimit, int limit,
+		Function<T, List<T>> selectFunction, Consumer<List<T>> resultConsumer) {
+		if (pageLimit < 0) {
+			selectAndExecuteWithCursor(limit, selectFunction, resultConsumer);
+			return;
+		}
+
+		var iterationCount = 0;
+		List<T> resultList = null;
+		do {
+			resultList = selectFunction.apply(resultList != null ? resultList.get(resultList.size() - 1) : null);
+			if (!resultList.isEmpty()) {
+				resultConsumer.accept(resultList);
+			}
+			if (++iterationCount >= pageLimit) {
+				break;
+			}
+		} while (resultList.size() >= limit);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/common/exception/enums/ErrorCode.java
+++ b/src/main/java/org/c4marathon/assignment/common/exception/enums/ErrorCode.java
@@ -12,6 +12,8 @@ public enum ErrorCode {
 	NOT_FOUND_SAVING_ACCOUNT(HttpStatus.NOT_FOUND, "적금 계좌가 존재하지 않습니다."),
 	NOT_FOUND_SETTLEMENT_MEMBER(HttpStatus.NOT_FOUND, "정산 멤버가 존재하지 않습니다."),
 	NOT_FOUND_SETTLEMENT(HttpStatus.NOT_FOUND, "정산 정보가 존재하지 않습니다."),
+	NOT_FOUND_USER(HttpStatus.NOT_FOUND, "유저 정보가 존재하지 않습니다."),
+
 	//409
 	DAILY_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "일일 한도를 초과했습니다."),
 	REDIS_RESET_EXCEPTION(HttpStatus.CONFLICT, "일일 한도 초기화 중입니다."),

--- a/src/main/java/org/c4marathon/assignment/common/exception/enums/SuccessCode.java
+++ b/src/main/java/org/c4marathon/assignment/common/exception/enums/SuccessCode.java
@@ -13,6 +13,8 @@ public enum SuccessCode {
 	CHARGE_MAIN_ACCOUNT_SUCCESS(HttpStatus.OK, "메인 계좌에 충전 완료되었습니다."),
 	TRANSFER_SAVING_ACCOUNT_SUCCESS(HttpStatus.OK, "적금 계좌에 송금 완료되었습니다."),
 	REQUEST_SETTLEMENT_SUCCESS(HttpStatus.OK, "정산 요청이 완료되었습니다."),
+	REQUEST_REMITTANCE_SETTLEMENT_SUCCESS(HttpStatus.OK, "정산 송금이 요청되었습니다."),
+	RECIEVE_REMITTANCE_SETTLEMENT_SUCCESS(HttpStatus.OK, "정산 송금 요청을 수락했습니다."),
 	REMITTANCE_SETTLEMENT_SUCCESS(HttpStatus.OK, "정산 송금이 완료되었습니다.");
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/org/c4marathon/assignment/common/string/StringEnum.java
+++ b/src/main/java/org/c4marathon/assignment/common/string/StringEnum.java
@@ -1,0 +1,19 @@
+package org.c4marathon.assignment.common.string;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum StringEnum {
+	PENDING_MAIL_TITLE("송금 요청이 도착했습니다. 72시간 내에 수령해주세요!"),
+	ALERT_24_MAIL_TITLE("24시간 내에 송금을 받지 않을 경우 송금 취소됩니다. 24시간 내에 수령해주세요!"),
+	REMITTANCE_FAIL_MAIL_TITLE( "72시간이 지나 송금이 자동 취소되었습니다.");
+
+	private final String message;
+
+	@Override
+	public String toString() {
+		return message;
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/controller/SettlementController.java
+++ b/src/main/java/org/c4marathon/assignment/controller/SettlementController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.c4marathon.assignment.common.dto.SuccessNonDataResponse;
 import org.c4marathon.assignment.common.exception.enums.SuccessCode;
+import org.c4marathon.assignment.dto.request.ReceiveSettlementRequestDto;
 import org.c4marathon.assignment.dto.request.RemittanceRequestDto;
 import org.c4marathon.assignment.dto.request.SettlementRequestDto;
 import org.c4marathon.assignment.service.SettlementService;
@@ -29,8 +30,14 @@ public class SettlementController {
 
 	@PostMapping("/remittance")
 	public SuccessNonDataResponse remittanceSettlement(@RequestBody @Valid RemittanceRequestDto requestDto) {
-		settleService.remittanceMoney(requestDto);
-		return SuccessNonDataResponse.success(SuccessCode.REMITTANCE_SETTLEMENT_SUCCESS);
+		settleService.requestRemittanceMoney(requestDto);
+		return SuccessNonDataResponse.success(SuccessCode.REQUEST_REMITTANCE_SETTLEMENT_SUCCESS);
+	}
+
+	@PostMapping("/receive")
+	public SuccessNonDataResponse receiveSettlement(@RequestBody @Valid ReceiveSettlementRequestDto requestDto) {
+		settleService.receiveMoney(requestDto);
+		return SuccessNonDataResponse.success(SuccessCode.RECIEVE_REMITTANCE_SETTLEMENT_SUCCESS);
 	}
 
 }

--- a/src/main/java/org/c4marathon/assignment/domain/Settlement.java
+++ b/src/main/java/org/c4marathon/assignment/domain/Settlement.java
@@ -3,8 +3,8 @@ package org.c4marathon.assignment.domain;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.c4marathon.assignment.domain.enums.SettlementStatus;
 import org.c4marathon.assignment.domain.enums.SettlementType;
+import org.c4marathon.assignment.domain.enums.TransactionStatus;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -36,9 +36,6 @@ public class Settlement extends BaseEntity{
 	@Column(name = "total_amount", nullable = false)
 	private long totalAmount;
 
-	@Column(name = "remain_amount", nullable = false)
-	private long remainAmount;
-
 	@Column(name = "people", nullable = false)
 	private int people;
 
@@ -48,16 +45,15 @@ public class Settlement extends BaseEntity{
 
 	@Column(name = "status", nullable = false)
 	@Enumerated(EnumType.STRING)
-	private SettlementStatus status;
+	private TransactionStatus status;
 
 	@OneToMany(mappedBy = "settlement", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 	private List<SettlementMember> settlementMembers = new ArrayList<>();
 
-	public Settlement(Long requestAccountId, long totalAmount,long remainAmount, int people, SettlementType type, SettlementStatus status,
+	public Settlement(Long requestAccountId, long totalAmount, int people, SettlementType type, TransactionStatus status,
 		List<SettlementMember> settlementMembers) {
 		this.requestAccountId = requestAccountId;
 		this.totalAmount = totalAmount;
-		this.remainAmount = remainAmount;
 		this.people = people;
 		this.type = type;
 		this.status = status;
@@ -68,14 +64,8 @@ public class Settlement extends BaseEntity{
 		this.settlementMembers = members;
 	}
 
-	public void updateRemainAmount(long remainAmount){
-		this.remainAmount = remainAmount;
-	}
-
-	public void updateStatus(SettlementStatus status){
+	public void updateStatus(TransactionStatus status){
 		this.status = status;
 	}
-
-
 
 }

--- a/src/main/java/org/c4marathon/assignment/domain/SettlementMember.java
+++ b/src/main/java/org/c4marathon/assignment/domain/SettlementMember.java
@@ -1,6 +1,6 @@
 package org.c4marathon.assignment.domain;
 
-import org.c4marathon.assignment.domain.enums.SettlementStatus;
+import org.c4marathon.assignment.domain.enums.TransactionStatus;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -12,10 +12,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(name = "settlement_member")
 @Getter
 @NoArgsConstructor
 public class SettlementMember {
@@ -31,26 +33,17 @@ public class SettlementMember {
 	@Column(name = "amount", nullable = false)
 	private long amount;
 
-	@Column(name = "status", nullable = false)
-	@Enumerated(EnumType.STRING)
-	private SettlementStatus status;
-
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "settlement_id", nullable = false)
 	private Settlement settlement;
 
-	public SettlementMember(long accountId, long amount, SettlementStatus status, Settlement settlement) {
+	public SettlementMember(long accountId, long amount, Settlement settlement) {
 		this.accountId = accountId;
 		this.amount = amount;
-		this.status = status;
 		this.settlement = settlement;
 	}
 
 	public void updateAmount(long money) {
 		this.amount += money;
-	}
-
-	public void updateStatus(SettlementStatus status) {
-		this.status = status;
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/domain/Transaction.java
+++ b/src/main/java/org/c4marathon/assignment/domain/Transaction.java
@@ -14,7 +14,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
@@ -55,13 +54,17 @@ public class Transaction extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	private TransactionType type;
 
+	@Column(name = "pending_mail_sent", nullable = false)
+	private boolean mailSent = false;
+
 	@Column(name = "pending_date")
 	private LocalDateTime pendingDate;
 
-	public Transaction(long senderAccountId, long receiverAccountId, long amount, TransactionStatus status,
+	public Transaction(long senderAccountId, long receiverAccountId,SettlementMember settlementMember, long amount, TransactionStatus status,
 		TransactionType type) {
 		this.senderAccountId = senderAccountId;
 		this.receiverAccountId = receiverAccountId;
+		this.settlementMember = settlementMember;
 		this.amount = amount;
 		this.status = status;
 		this.type = type;
@@ -78,6 +81,10 @@ public class Transaction extends BaseEntity {
 
 	public void cancelTransaction() {
 		this.status = TransactionStatus.CANCELED;
+	}
+
+	public void pendingMailSent(){
+		this.mailSent = true;
 	}
 
 }

--- a/src/main/java/org/c4marathon/assignment/domain/Transaction.java
+++ b/src/main/java/org/c4marathon/assignment/domain/Transaction.java
@@ -1,0 +1,83 @@
+package org.c4marathon.assignment.domain;
+
+import java.time.LocalDateTime;
+
+import org.c4marathon.assignment.domain.enums.TransactionStatus;
+import org.c4marathon.assignment.domain.enums.TransactionType;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "transaction")
+@Getter
+@NoArgsConstructor
+public class Transaction extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "transaction_id", nullable = false)
+	private long id;
+
+	@Size(max = 20)
+	@NotNull
+	@Column(name = "sender_account_id", nullable = false, length = 20)
+	private long senderAccountId;
+
+	@Size(max = 20)
+	@NotNull
+	@Column(name = "receiver_account_id", nullable = false, length = 20)
+	private long receiverAccountId;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "settlement_member_id", nullable = false)
+	private SettlementMember settlementMember;
+
+	@Column(name = "amount", nullable = false)
+	private long amount;
+
+	@Enumerated(EnumType.STRING)
+	private TransactionStatus status; 
+
+	@Enumerated(EnumType.STRING)
+	private TransactionType type;
+
+	@Column(name = "pending_date")
+	private LocalDateTime pendingDate;
+
+	public Transaction(long senderAccountId, long receiverAccountId, long amount, TransactionStatus status,
+		TransactionType type) {
+		this.senderAccountId = senderAccountId;
+		this.receiverAccountId = receiverAccountId;
+		this.amount = amount;
+		this.status = status;
+		this.type = type;
+	}
+
+	public void pendingTransaction() {
+		this.status = TransactionStatus.PENDING;
+		this.pendingDate = LocalDateTime.now();
+	}
+
+	public void successTransaction() {
+		this.status = TransactionStatus.SUCCESS;
+	}
+
+	public void cancelTransaction() {
+		this.status = TransactionStatus.CANCELED;
+	}
+
+}

--- a/src/main/java/org/c4marathon/assignment/domain/Transaction.java
+++ b/src/main/java/org/c4marathon/assignment/domain/Transaction.java
@@ -50,7 +50,7 @@ public class Transaction extends BaseEntity {
 	private long amount;
 
 	@Enumerated(EnumType.STRING)
-	private TransactionStatus status; 
+	private TransactionStatus status;
 
 	@Enumerated(EnumType.STRING)
 	private TransactionType type;

--- a/src/main/java/org/c4marathon/assignment/domain/User.java
+++ b/src/main/java/org/c4marathon/assignment/domain/User.java
@@ -6,6 +6,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,8 +25,15 @@ public class User extends BaseEntity{
 	@Column(name = "username", nullable = false, length = 30)
 	private String username;
 
-	public User(String username) {
+	@Column(name = "email", nullable = false, length = 30, unique = true)
+	@NotBlank(message = "이메일은 필수 입력 항목입니다.")
+	@Size(max = 30, message = "이메일은 최대 30자까지 입력 가능합니다.")
+	@Email(message = "이메일 형식이 잘못되었습니다.")
+	private String email;
+
+	public User(String username, String email) {
 		this.username = username;
+		this.email = email;
 	}
 
 }

--- a/src/main/java/org/c4marathon/assignment/domain/enums/TransactionStatus.java
+++ b/src/main/java/org/c4marathon/assignment/domain/enums/TransactionStatus.java
@@ -1,6 +1,7 @@
 package org.c4marathon.assignment.domain.enums;
 
 public enum SettlementStatus {
+	REQUESTED,
 	PENDING,
 	SUCCESS
 }

--- a/src/main/java/org/c4marathon/assignment/domain/enums/TransactionStatus.java
+++ b/src/main/java/org/c4marathon/assignment/domain/enums/TransactionStatus.java
@@ -1,7 +1,8 @@
 package org.c4marathon.assignment.domain.enums;
 
-public enum SettlementStatus {
+public enum TransactionStatus {
 	REQUESTED,
 	PENDING,
-	SUCCESS
+	SUCCESS,
+	CANCELED
 }

--- a/src/main/java/org/c4marathon/assignment/domain/enums/TransactionType.java
+++ b/src/main/java/org/c4marathon/assignment/domain/enums/TransactionType.java
@@ -1,0 +1,6 @@
+package org.c4marathon.assignment.domain.enums;
+
+public enum TransactionType {
+	REALTIME,
+	DELAYED
+}

--- a/src/main/java/org/c4marathon/assignment/dto/request/ChargeSavingAccountRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/dto/request/ChargeSavingAccountRequestDto.java
@@ -1,6 +1,5 @@
 package org.c4marathon.assignment.dto.request;
 
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 
 public record ChargeSavingAccountRequestDto(

--- a/src/main/java/org/c4marathon/assignment/dto/request/ReceiveSettlementRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/dto/request/ReceiveSettlementRequestDto.java
@@ -1,0 +1,7 @@
+package org.c4marathon.assignment.dto.request;
+
+public record ReceiveSettlementRequestDto(
+	long transactionId,
+	long settlementMemberId
+) {
+}

--- a/src/main/java/org/c4marathon/assignment/dto/request/RemittanceRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/dto/request/RemittanceRequestDto.java
@@ -1,7 +1,17 @@
 package org.c4marathon.assignment.dto.request;
 
+import org.c4marathon.assignment.domain.enums.TransactionType;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
 public record RemittanceRequestDto(
 	long settlementId,
-	long settlementMemberAccountId
+	long requestAccountId,
+	long settlementMemberAccountId,
+	@Positive(message = "양수값을 정산해야합니다.")
+	long amount,
+	@NotNull
+	TransactionType type
 ) {
 }

--- a/src/main/java/org/c4marathon/assignment/dto/request/SignUpRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/dto/request/SignUpRequestDto.java
@@ -1,11 +1,16 @@
 package org.c4marathon.assignment.dto.request;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record SignUpRequestDto(
 	@NotBlank
 	@Size(min = 2, max = 30)
-	String username
+	String username,
+	@NotBlank(message = "이메일을 입력해주세요.")
+	@Size(max = 30, message = "이메일은 최대 30자까지 입력 가능합니다.")
+	@Email(message = "이메일 형식이 올바르지 않습니다.")
+	String email
 ) {
 }

--- a/src/main/java/org/c4marathon/assignment/repository/SettlementMemberRepository.java
+++ b/src/main/java/org/c4marathon/assignment/repository/SettlementMemberRepository.java
@@ -2,7 +2,6 @@ package org.c4marathon.assignment.repository;
 
 import java.util.Optional;
 
-import org.c4marathon.assignment.domain.Settlement;
 import org.c4marathon.assignment.domain.SettlementMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -15,4 +14,6 @@ public interface SettlementMemberRepository extends JpaRepository<SettlementMemb
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("SELECT sm FROM SettlementMember sm WHERE sm.settlement.id = :settlementId and sm.accountId = :memberAccountId")
 	Optional<SettlementMember> findByAccountIdWithXLock(@Param("settlementId") Long settlementId, @Param("memberAccountId") Long memberAccountId);
+
+	Optional<SettlementMember> findBySettlement(long settlementId);
 }

--- a/src/main/java/org/c4marathon/assignment/repository/TransactionRepository.java
+++ b/src/main/java/org/c4marathon/assignment/repository/TransactionRepository.java
@@ -1,7 +1,91 @@
 package org.c4marathon.assignment.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.c4marathon.assignment.domain.Transaction;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface TransactionRepository  extends JpaRepository<Transaction, Long> {
+public interface TransactionRepository extends JpaRepository<Transaction, Long> {
+
+	@Query("""
+		    SELECT t 
+		    FROM Transaction t 
+		    WHERE t.status = 'PENDING' 
+		    AND t.pendingDate <= :endDate
+		    AND t.mailSent = FALSE
+		    ORDER BY t.pendingDate, t.id
+		    LIMIT :size
+		""")
+	List<Transaction> findRemindableTransactions(
+		@Param("endDate") LocalDateTime endDate,
+		@Param("size") int size
+	);
+
+	@Query("""
+		    SELECT t 
+		    FROM Transaction t 
+		    WHERE t.status = 'PENDING' 
+		    AND t.pendingDate <= :endDate
+		    AND t.mailSent = FALSE
+		    AND (t.pendingDate > :lastPendingDate 
+		         OR (t.pendingDate = :lastPendingDate AND t.id > :lastTransactionId))
+		    ORDER BY t.pendingDate, t.id
+		    LIMIT :size
+		""")
+	List<Transaction> findRemindableTransactionsWithCursor(
+		@Param("endDate") LocalDateTime endDate,
+		@Param("lastPendingDate") LocalDateTime lastPendingDate,
+		@Param("lastTransactionId") Long lastTransactionId,
+		@Param("size") int size
+	);
+
+	@Modifying
+	@Query("""
+		    UPDATE Transaction t
+		    SET t.mailSent = TRUE
+		    WHERE t.id IN :transactionIds
+		""")
+	void updateMailSent(@Param("transactionIds") List<Long> transactionIds);
+
+	@Query("""
+		    SELECT t 
+		    FROM Transaction t 
+		    WHERE t.status = 'PENDING' 
+		    AND t.pendingDate <= :expirationTime
+		    ORDER BY t.pendingDate, t.id
+		    LIMIT :size
+		""")
+	List<Transaction> findExpiredTransactions(
+		@Param("expirationTime") LocalDateTime expirationTime,
+		@Param("size") int size
+	);
+
+	@Query("""
+		    SELECT t 
+		    FROM Transaction t 
+		    WHERE t.status = 'PENDING' 
+		    AND t.pendingDate <= :expirationTime
+		   	AND (t.pendingDate > :lastPendingDate
+		             OR (t.pendingDate = :lastPendingDate AND t.id > :lastTransactionId))
+		    ORDER BY t.pendingDate, t.id
+		    LIMIT :size
+		""")
+	List<Transaction> findExpiredTransactionsWithCursor(
+		@Param("expirationTime") LocalDateTime expirationTime,
+		@Param("lastPendingDate") LocalDateTime lastPendingDate,
+		@Param("lastTransactionId") Long lastTransactionId,
+		@Param("size") int size
+	);
+
+	@Modifying
+	@Query("""
+		    UPDATE Transaction t 
+		    SET t.status = 'CANCELED' 
+		    WHERE t.id IN :transactionIds
+		""")
+	void updateExpiredTransactions(@Param("transactionIds") List<Long> transactionIds);
 }

--- a/src/main/java/org/c4marathon/assignment/repository/TransactionRepository.java
+++ b/src/main/java/org/c4marathon/assignment/repository/TransactionRepository.java
@@ -1,0 +1,7 @@
+package org.c4marathon.assignment.repository;
+
+import org.c4marathon.assignment.domain.Transaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TransactionRepository  extends JpaRepository<Transaction, Long> {
+}

--- a/src/main/java/org/c4marathon/assignment/repository/TransactionRepositoryCursor.java
+++ b/src/main/java/org/c4marathon/assignment/repository/TransactionRepositoryCursor.java
@@ -1,0 +1,32 @@
+package org.c4marathon.assignment.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.c4marathon.assignment.domain.Transaction;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class TransactionRepositoryCursor {
+	private final TransactionRepository transactionRepository;
+
+	/**
+	 *  주어진 endDate전까지 모든 Transaction 정보를 size만큼씩 가져온다.
+	 */
+	public List<Transaction> findRemindableTransactions(LocalDateTime endDate,LocalDateTime pendingDate, Long lastDateId, int size) {
+		if (lastDateId == null) {
+			return transactionRepository.findRemindableTransactions(endDate, size);
+		}
+		return transactionRepository.findRemindableTransactionsWithCursor(endDate, pendingDate, lastDateId, size);
+	}
+
+	public List<Transaction> findExpiredTransactions(LocalDateTime endDate,LocalDateTime pendingDate, Long lastDateId, int size) {
+		if (lastDateId == null) {
+			return transactionRepository.findExpiredTransactions(endDate, size);
+		}
+		return transactionRepository.findExpiredTransactionsWithCursor(endDate, pendingDate, lastDateId, size);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/service/SettlementService.java
+++ b/src/main/java/org/c4marathon/assignment/service/SettlementService.java
@@ -1,33 +1,48 @@
 package org.c4marathon.assignment.service;
 
 import java.security.SecureRandom;
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.c4marathon.assignment.common.exception.NotFoundException;
-import org.c4marathon.assignment.common.exception.enums.ErrorCode;
+import org.c4marathon.assignment.domain.MainAccount;
 import org.c4marathon.assignment.domain.Settlement;
 import org.c4marathon.assignment.domain.SettlementMember;
-import org.c4marathon.assignment.domain.enums.SettlementStatus;
+import org.c4marathon.assignment.domain.Transaction;
+import org.c4marathon.assignment.domain.User;
+import org.c4marathon.assignment.domain.enums.TransactionStatus;
 import org.c4marathon.assignment.domain.enums.SettlementType;
+import org.c4marathon.assignment.domain.enums.TransactionType;
+import org.c4marathon.assignment.dto.request.ReceiveSettlementRequestDto;
 import org.c4marathon.assignment.dto.request.RemittanceRequestDto;
 import org.c4marathon.assignment.dto.request.SettlementRequestDto;
-import org.c4marathon.assignment.repository.SettlementMemberRepository;
 import org.c4marathon.assignment.repository.SettlementRepository;
+import org.c4marathon.assignment.repository.TransactionRepository;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
+import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SettlementService {
 
 	private final SettlementRepository settlementRepository;
-	private final SettlementMemberRepository settlementMemberRepository;
+	private final TransactionRepository transactionRepository;
+	private final UserService userService;
+	private final MainAccountService mainAccountService;
+	private final JavaMailSender javaMailSender;
+	private static final int MAX_RETRY_COUNT = 3;
 
 	/**
 	 * [Step3] 정산
@@ -55,16 +70,16 @@ public class SettlementService {
 		long baseAmount = totalAmount / totalPeople;
 		long remainAmount = totalAmount % totalPeople;
 
-		Settlement settlement = new Settlement(requestDto.requestAccountId(), totalAmount, totalAmount, totalPeople,
-			SettlementType.EQUAL, SettlementStatus.PENDING, null);
+		Settlement settlement = new Settlement(requestDto.requestAccountId(), totalAmount, totalPeople,
+			SettlementType.EQUAL, TransactionStatus.REQUESTED, null);
 
 		//기본 금액 전체 할당
 		List<SettlementMember> updatedMembers = settlementMemberIds.stream().map(memberId -> new SettlementMember(
-			memberId , baseAmount, SettlementStatus.PENDING, settlement
+			memberId, baseAmount, settlement
 		)).collect(Collectors.toList());
 
 		//남은 금액 1원씩 할당
-		if(remainAmount > 0) {
+		if (remainAmount > 0) {
 			Collections.shuffle(updatedMembers);
 			for (int i = 0; i < remainAmount; i++) {
 				SettlementMember member = updatedMembers.get(i);
@@ -87,32 +102,31 @@ public class SettlementService {
 		SecureRandom random = new SecureRandom();
 
 		//Settlement
-		Settlement settlement = new Settlement(requestDto.requestAccountId(), totalAmount, totalAmount, totalPeople, SettlementType.RANDOM, SettlementStatus.PENDING, null);
+		Settlement settlement = new Settlement(requestDto.requestAccountId(), totalAmount, totalPeople,
+			SettlementType.RANDOM, TransactionStatus.REQUESTED, null);
 
 		//랜덤으로 돈 배정
 		Collections.shuffle(settlementMemberIds);
 		int remainAmount = totalAmount;
 		List<SettlementMember> updatedMembers = new ArrayList<>();
 
-		for(int i = 0; i < totalPeople - 1; i++) {
+		for (int i = 0; i < totalPeople - 1; i++) {
 			int randomAmount = random.nextInt(remainAmount + 1);
 			remainAmount -= randomAmount;
 			if (randomAmount > 0) { // 0원을 받는 사람은 저장X
 				updatedMembers.add(new SettlementMember(
 					settlementMemberIds.get(i),
 					randomAmount,
-					SettlementStatus.PENDING,
 					settlement
 				));
 			}
 		}
 
 		//남은 돈이 있으면 마지막 사람에게 할당
-		if(remainAmount > 0) {
+		if (remainAmount > 0) {
 			updatedMembers.add(new SettlementMember(
 				settlementMemberIds.get(totalPeople - 1),
 				remainAmount,
-				SettlementStatus.PENDING,
 				settlement
 			));
 		}
@@ -122,29 +136,115 @@ public class SettlementService {
 	}
 
 	/**
-	 * [Step3] 정산을 위한 송금하기
-	 * member는 상태값만 변경하고
-	 * settlement의 remainAmount를 차감한다.
+	 * [Step4] 정산을 위한 송금 요청하기(대기)
+	 *
 	 * */
 	@Transactional(isolation = Isolation.READ_COMMITTED)
-	public void remittanceMoney(RemittanceRequestDto requestDto) {
+	public void requestRemittanceMoney(RemittanceRequestDto requestDto) {
+		Transaction transaction = new Transaction(requestDto.requestAccountId(), requestDto.settlementMemberAccountId(),
+			requestDto.amount(), TransactionStatus.REQUESTED, requestDto.type());
+		transactionRepository.save(transaction);
 
-		SettlementMember member = settlementMemberRepository.findByAccountIdWithXLock(requestDto.settlementId(),
-			requestDto.settlementMemberAccountId()).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_SETTLEMENT_MEMBER));
-
-		if (member.getStatus() == SettlementStatus.SUCCESS) {
-			throw new IllegalStateException(ErrorCode.ALREADY_REMITTANCE_SUCCESS.getMessage());
+		if (requestDto.type() == TransactionType.REALTIME) {
+			recieveMoney(transaction); // ✅  돈바로 받는 로직이랑 같을텐데 일단 내 계좌에서 돈을 빼는 로직은 구현  + 돈 보내는 로직 다 구현
+		} else {
+			transaction.pendingTransaction(); // 상태 변환
+			transactionRepository.save(transaction);
+			sendNotification(requestDto.requestAccountId());
+			//✅ 돈바로 받는 로직이랑 같을텐데 일단 내 계좌에서 돈을 빼는 로직은 구현
 		}
 
-		Settlement settlement = settlementRepository.findByIdWithXLock(requestDto.settlementId()).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_SETTLEMENT));
-
-		member.updateStatus(SettlementStatus.SUCCESS);//정산 상태 처리
-		settlement.updateRemainAmount(settlement.getRemainAmount() - member.getAmount()); //남은 정산금액 업데이트
-		if (settlement.getRemainAmount() == 0) { //마지막 사람이 정산 하면
-			settlement.updateStatus(SettlementStatus.SUCCESS); //정산 완료 처리
-		}
-
-		settlementMemberRepository.save(member);
-		settlementRepository.save(settlement);
 	}
+
+
+	/**
+	 * [Step4] 돈을 받는 함수
+	 * 전체가 다 정산되면 Settlement에 status Success로 변경
+	 * */
+	@Transactional
+	public void receiveMoney(ReceiveSettlementRequestDto requestDto) {
+		//requestDto.transactionId, requestDto.settlementMemberId
+		Transaction transaction = transactionRepository.findByIdWithXLock(transactionId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_TRANSACTION));
+
+		if (transaction.getStatus() != TransactionStatus.PENDING) {
+			throw new IllegalStateException("이미 완료된 송금입니다.");
+		}
+
+		MainAccount receiver = mainAccountRepository.findByIdWithXLock(transaction.getReceiverId())
+			.orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ACCOUNT));
+
+		receiver.updateBalance(transaction.getAmount());
+		transaction.completeTransaction();
+
+		mainAccountRepository.save(receiver);
+		transactionRepository.save(transaction);
+	}
+
+	/**
+	 * [Step4] 돈을 보냈다는 알림 보내는 함수
+	 * "송금 요청이 도착했습니다. 72시간 내에 수령해주세요!"
+	 * */
+	private void sendNotification(long requestAccountId) {
+		final String MAIL_SUBJECT = "송금 요청이 도착했습니다. 72시간 내에 수령해주세요!";
+		int attempt = 0;
+		boolean isSent = false;
+
+		MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+		MainAccount mainAccount = mainAccountService.getMainAccount(requestAccountId);
+		User user = userService.getUser(mainAccount.getUser().getId());
+
+		while (attempt < MAX_RETRY_COUNT && !isSent) {
+			try {
+				MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+				mimeMessageHelper.setTo(user.getEmail());
+				mimeMessageHelper.setSubject(MAIL_SUBJECT);
+				javaMailSender.send(mimeMessage);
+				isSent = true;
+			} catch (Exception e) {
+				attempt++;
+				log.warn("메일 전송 실패 ({}회차): {}, 에러: {}", attempt, user.getEmail(), e.getMessage());
+
+				if (attempt < MAX_RETRY_COUNT) {
+					try {
+						Thread.sleep(2000);
+					} catch (InterruptedException ie) {
+						Thread.currentThread().interrupt();
+						log.error("메일 전송 재시도 대기 중 인터럽트 발생: {}", ie.getMessage());
+					}
+				} else {
+					log.error("메일 전송 최종 실패: {}", user.getEmail());
+				}
+			}
+		}
+	}
+
+	/**
+	 * [Step4] 24시간 남은 송금 리마인드 알림
+	 * */
+	@Scheduled(fixedRate = 60000) // 1분마다 실행 ==> 굳이 10분 마다 해도될듯?
+	public void sendRemindersForPendingTransactions() {
+		List<Transaction> pendingTransactions = transactionRepository.findRemindableTransactions(LocalDateTime.now().minusHours(48));
+
+		for (Transaction transaction : pendingTransactions) {
+			sendNotification(transaction.getReceiverId(), "송금을 받을 시간이 24시간 남았습니다!");
+		}
+	}
+
+	/**
+	 * [Step4] (72시간 초과 시 자동 취소)
+	 * */
+	@Scheduled(fixedRate = 60000) // 1분마다 실행
+	@Transactional
+	public void cancelExpiredTransactions() {
+		List<Transaction> expiredTransactions = transactionRepository.findExpiredTransactions(LocalDateTime.now().minusHours(72));
+
+		for (Transaction transaction : expiredTransactions) {
+			transaction.cancelTransaction();
+			transactionRepository.save(transaction);
+			sendNotification(transaction.getSenderId(), "72시간이 지나 송금이 자동 취소되었습니다.");
+		}
+	}
+
+
 }

--- a/src/main/java/org/c4marathon/assignment/service/SettlementService.java
+++ b/src/main/java/org/c4marathon/assignment/service/SettlementService.java
@@ -173,7 +173,7 @@ public class SettlementService {
 	}
 
 	/**
-	 * [Step4] 만료된 송금 처리 (환불 + 상태 변경)
+	 * [Step4] (72시간 초과 시 자동 취소) >  (환불 + 상태 변경)
 	 */
 	@Transactional
 	public void processExpiredTransactions(List<Transaction> transactions) {

--- a/src/main/java/org/c4marathon/assignment/service/SettlementService.java
+++ b/src/main/java/org/c4marathon/assignment/service/SettlementService.java
@@ -197,7 +197,7 @@ public class SettlementService {
 	 * */
 	@Scheduled(fixedRate = 300000)
 	public void sendRemindersForPendingTransactions() {
-		LocalDateTime endDate = LocalDateTime.now().minusHours(24);
+		LocalDateTime endDate = LocalDateTime.now().minusHours(48);
 
 		QueryExecuteTemplate.<Transaction>selectAndExecuteWithCursorAndPageLimit(
 			-1,

--- a/src/main/java/org/c4marathon/assignment/service/SettlementService.java
+++ b/src/main/java/org/c4marathon/assignment/service/SettlementService.java
@@ -1,13 +1,16 @@
 package org.c4marathon.assignment.service;
 
 import java.security.SecureRandom;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.c4marathon.assignment.common.QueryExecuteTemplate;
+import org.c4marathon.assignment.common.exception.NotFoundException;
+import org.c4marathon.assignment.common.exception.enums.ErrorCode;
+import org.c4marathon.assignment.common.string.StringEnum;
 import org.c4marathon.assignment.domain.MainAccount;
 import org.c4marathon.assignment.domain.Settlement;
 import org.c4marathon.assignment.domain.SettlementMember;
@@ -19,8 +22,11 @@ import org.c4marathon.assignment.domain.enums.TransactionType;
 import org.c4marathon.assignment.dto.request.ReceiveSettlementRequestDto;
 import org.c4marathon.assignment.dto.request.RemittanceRequestDto;
 import org.c4marathon.assignment.dto.request.SettlementRequestDto;
+import org.c4marathon.assignment.repository.SettlementMemberRepository;
 import org.c4marathon.assignment.repository.SettlementRepository;
 import org.c4marathon.assignment.repository.TransactionRepository;
+import org.c4marathon.assignment.repository.TransactionRepositoryCursor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -28,6 +34,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
+import io.netty.util.internal.StringUtil;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,11 +45,16 @@ import lombok.extern.slf4j.Slf4j;
 public class SettlementService {
 
 	private final SettlementRepository settlementRepository;
+	private final SettlementMemberRepository settlementMemberRepository;
 	private final TransactionRepository transactionRepository;
+	private final TransactionRepositoryCursor transactionRepositoryCursor;
 	private final UserService userService;
 	private final MainAccountService mainAccountService;
 	private final JavaMailSender javaMailSender;
+	private final RedisTemplate<String,Long> redisTemplate;
+
 	private static final int MAX_RETRY_COUNT = 3;
+	private static final int BATCH_SIZE = 1000;
 
 	/**
 	 * [Step3] 정산
@@ -56,6 +68,170 @@ public class SettlementService {
 		} else {
 			divideRandom(requestDto);
 		}
+	}
+
+
+	/**
+	 * [Step4] 돈을 보냈다는 알림 보내는 함수
+	 * "송금 요청이 도착했습니다. 72시간 내에 수령해주세요!"
+	 * */
+	private void sendNotification(long requestAccountId, String title) {
+		int attempt = 0;
+		boolean isSent = false;
+
+		MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+		MainAccount mainAccount = mainAccountService.getMainAccount(requestAccountId);
+		User user = userService.getUser(mainAccount.getUser().getId());
+
+		while (attempt < MAX_RETRY_COUNT && !isSent) {
+			try {
+				MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+				mimeMessageHelper.setTo(user.getEmail());
+				mimeMessageHelper.setSubject(title);
+				javaMailSender.send(mimeMessage);
+				isSent = true;
+			} catch (Exception e) {
+				attempt++;
+				log.warn("메일 전송 실패 ({}회차): {}, 에러: {}", attempt, user.getEmail(), e.getMessage());
+
+				if (attempt < MAX_RETRY_COUNT) {
+					try {
+						Thread.sleep(2000);
+					} catch (InterruptedException ie) {
+						Thread.currentThread().interrupt();
+						log.error("메일 전송 재시도 대기 중 인터럽트 발생: {}", ie.getMessage());
+					}
+				} else {
+					log.error("메일 전송 최종 실패: {}", user.getEmail());
+				}
+			}
+		}
+	}
+
+	/**
+	 * [Step4] 정산을 위한 송금 요청하기(대기)
+	 *
+	 * */
+	@Transactional(isolation = Isolation.READ_COMMITTED)
+	public void requestRemittanceMoney(RemittanceRequestDto requestDto) {
+		SettlementMember settlementMember = settlementMemberRepository.findBySettlement(requestDto.settlementId()).orElseThrow(() -> new NotFoundException(
+			ErrorCode.NOT_FOUND_SETTLEMENT_MEMBER));
+		Transaction transaction = new Transaction(requestDto.requestAccountId(), requestDto.settlementMemberAccountId(),settlementMember,
+			requestDto.amount(), TransactionStatus.REQUESTED, requestDto.type());
+		transactionRepository.save(transaction);
+
+		if (requestDto.type() == TransactionType.REALTIME) {
+			// recieveMoney(transaction);
+			// ✅ 돈 받는 로직 추가 예정
+		} else {
+			transaction.pendingTransaction(); // 상태 변환
+			transactionRepository.save(transaction);
+			sendNotification(requestDto.requestAccountId(), StringEnum.PENDING_MAIL_TITLE.toString());
+			//✅ 일단 내 계좌에서 돈을 빼고, 돈이 부족한지 파악하고, 충전가능하다면 충전하는 로직 기존의것 디벨롭해서 추가 예정
+		}
+
+	}
+
+	/**
+	 * [Step4] 돈을 받는 함수
+	 * 전체가 다 정산되면 Settlement에 status Success로 변경
+	 * @requestDto
+	 * long transactionId
+	 * long settlementMemberId
+	 * */
+	@Transactional
+	public void receiveMoney(ReceiveSettlementRequestDto requestDto) {
+		//(1) TransactionId를 조회해서 해당 transaction SUCCESS 상태 변환
+
+		//(2) SettlementMemberId로 SettlementMent 조회해서 => 모든 Settlement들 조회
+		//(3) Settlement에 있는 내역들이 모두 정산되었으면 SUCCESS로 상태 바꾸기 ( 부분이면 PENDING으로변경)
+		//(3-1) -> 이러기 위해서는 SettlementMember에 정산 여부 상태값이 다시 추가 되어야 할것 같다.
+
+		// queuePendingTransaction(senderId, recieverId, amount);
+	}
+
+	/**
+	 * [Step4] (72시간 초과 시 자동 취소)
+	 * */
+	@Scheduled(fixedRate = 60000) // 1분마다 실행
+	@Transactional
+	public void cancelExpiredTransactions() {
+		LocalDateTime expirationTime = LocalDateTime.now().minusHours(72);
+
+		QueryExecuteTemplate.<Transaction>selectAndExecuteWithCursorAndPageLimit(
+			-1,
+			BATCH_SIZE,
+			lastTransaction -> transactionRepositoryCursor.findExpiredTransactions(
+				expirationTime,
+				lastTransaction == null ? null : lastTransaction.getPendingDate(),
+				lastTransaction == null ? null : lastTransaction.getId(),
+				BATCH_SIZE
+			),
+			this::processExpiredTransactions
+		);
+
+	}
+
+	/**
+	 * [Step4] 만료된 송금 처리 (환불 + 상태 변경)
+	 */
+	@Transactional
+	public void processExpiredTransactions(List<Transaction> transactions) {
+		List<Long> transactionIds = new ArrayList<>();
+
+		for (Transaction transaction : transactions) {
+			transaction.cancelTransaction();
+			transactionIds.add(transaction.getId());
+		}
+		transactionRepository.updateExpiredTransactions(transactionIds);
+
+		//환불 송금 요청
+		for (Transaction transaction : transactions) {
+			refundToSender(transaction);
+		}
+	}
+
+	/**
+	 * [Step4] 24시간 남은 송금 리마인드 알림
+	 * 5분마다 스케줄러를 통해 24시간 남은 송금 조회
+	 * */
+	@Scheduled(fixedRate = 300000)
+	public void sendRemindersForPendingTransactions() {
+		LocalDateTime endDate = LocalDateTime.now().minusHours(24);
+
+		QueryExecuteTemplate.<Transaction>selectAndExecuteWithCursorAndPageLimit(
+			-1,
+			BATCH_SIZE,
+			lastTransaction -> transactionRepositoryCursor.findRemindableTransactions(
+				endDate,
+				lastTransaction == null ? null : lastTransaction.getPendingDate(),
+				lastTransaction == null ? null : lastTransaction.getId(),
+				BATCH_SIZE
+			),
+			this::processMailMultiThread
+		);
+	}
+
+	/**
+	 * 1안 : 멀티스레드+ 동기적으로 메일 전송
+	 * (2안 : 메일 전송을 비동기로 처리하고 메일 전송 실패 건에 대해서만 롤백하는밥법)
+	 * */
+	@Transactional
+	public void processMailMultiThread(List<Transaction> transactions) {
+		transactions.parallelStream().forEach(transaction -> {
+			sendNotification(transaction.getReceiverAccountId(), StringEnum.ALERT_24_MAIL_TITLE.toString());
+		});
+
+		updateMailSentStatus(transactions);
+	}
+
+	@Transactional
+	public void updateMailSentStatus(List<Transaction> transactions) {
+		List<Long> transactionIds = transactions.stream()
+			.map(Transaction::getId)
+			.toList();
+
+		transactionRepository.updateMailSent(transactionIds);
 	}
 
 	/**
@@ -135,116 +311,26 @@ public class SettlementService {
 		settlementRepository.save(settlement);
 	}
 
-	/**
-	 * [Step4] 정산을 위한 송금 요청하기(대기)
-	 *
-	 * */
-	@Transactional(isolation = Isolation.READ_COMMITTED)
-	public void requestRemittanceMoney(RemittanceRequestDto requestDto) {
-		Transaction transaction = new Transaction(requestDto.requestAccountId(), requestDto.settlementMemberAccountId(),
-			requestDto.amount(), TransactionStatus.REQUESTED, requestDto.type());
-		transactionRepository.save(transaction);
-
-		if (requestDto.type() == TransactionType.REALTIME) {
-			recieveMoney(transaction); // ✅  돈바로 받는 로직이랑 같을텐데 일단 내 계좌에서 돈을 빼는 로직은 구현  + 돈 보내는 로직 다 구현
-		} else {
-			transaction.pendingTransaction(); // 상태 변환
-			transactionRepository.save(transaction);
-			sendNotification(requestDto.requestAccountId());
-			//✅ 돈바로 받는 로직이랑 같을텐데 일단 내 계좌에서 돈을 빼는 로직은 구현
-		}
-
-	}
-
-
-	/**
-	 * [Step4] 돈을 받는 함수
-	 * 전체가 다 정산되면 Settlement에 status Success로 변경
-	 * */
-	@Transactional
-	public void receiveMoney(ReceiveSettlementRequestDto requestDto) {
-		//requestDto.transactionId, requestDto.settlementMemberId
-		Transaction transaction = transactionRepository.findByIdWithXLock(transactionId)
-			.orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_TRANSACTION));
-
-		if (transaction.getStatus() != TransactionStatus.PENDING) {
-			throw new IllegalStateException("이미 완료된 송금입니다.");
-		}
-
-		MainAccount receiver = mainAccountRepository.findByIdWithXLock(transaction.getReceiverId())
-			.orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ACCOUNT));
-
-		receiver.updateBalance(transaction.getAmount());
-		transaction.completeTransaction();
-
-		mainAccountRepository.save(receiver);
-		transactionRepository.save(transaction);
-	}
-
-	/**
-	 * [Step4] 돈을 보냈다는 알림 보내는 함수
-	 * "송금 요청이 도착했습니다. 72시간 내에 수령해주세요!"
-	 * */
-	private void sendNotification(long requestAccountId) {
-		final String MAIL_SUBJECT = "송금 요청이 도착했습니다. 72시간 내에 수령해주세요!";
-		int attempt = 0;
-		boolean isSent = false;
-
-		MimeMessage mimeMessage = javaMailSender.createMimeMessage();
-		MainAccount mainAccount = mainAccountService.getMainAccount(requestAccountId);
-		User user = userService.getUser(mainAccount.getUser().getId());
-
-		while (attempt < MAX_RETRY_COUNT && !isSent) {
-			try {
-				MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
-				mimeMessageHelper.setTo(user.getEmail());
-				mimeMessageHelper.setSubject(MAIL_SUBJECT);
-				javaMailSender.send(mimeMessage);
-				isSent = true;
-			} catch (Exception e) {
-				attempt++;
-				log.warn("메일 전송 실패 ({}회차): {}, 에러: {}", attempt, user.getEmail(), e.getMessage());
-
-				if (attempt < MAX_RETRY_COUNT) {
-					try {
-						Thread.sleep(2000);
-					} catch (InterruptedException ie) {
-						Thread.currentThread().interrupt();
-						log.error("메일 전송 재시도 대기 중 인터럽트 발생: {}", ie.getMessage());
-					}
-				} else {
-					log.error("메일 전송 최종 실패: {}", user.getEmail());
-				}
-			}
-		}
-	}
-
-	/**
-	 * [Step4] 24시간 남은 송금 리마인드 알림
-	 * */
-	@Scheduled(fixedRate = 60000) // 1분마다 실행 ==> 굳이 10분 마다 해도될듯?
-	public void sendRemindersForPendingTransactions() {
-		List<Transaction> pendingTransactions = transactionRepository.findRemindableTransactions(LocalDateTime.now().minusHours(48));
-
-		for (Transaction transaction : pendingTransactions) {
-			sendNotification(transaction.getReceiverId(), "송금을 받을 시간이 24시간 남았습니다!");
-		}
-	}
-
-	/**
-	 * [Step4] (72시간 초과 시 자동 취소)
-	 * */
-	@Scheduled(fixedRate = 60000) // 1분마다 실행
-	@Transactional
-	public void cancelExpiredTransactions() {
-		List<Transaction> expiredTransactions = transactionRepository.findExpiredTransactions(LocalDateTime.now().minusHours(72));
-
-		for (Transaction transaction : expiredTransactions) {
-			transaction.cancelTransaction();
-			transactionRepository.save(transaction);
-			sendNotification(transaction.getSenderId(), "72시간이 지나 송금이 자동 취소되었습니다.");
+	private void queuePendingTransaction(long senderId, long recieverId, long amount) {
+		try {
+			String key = "transfer:" + senderId + ":" + recieverId + ":" + amount;
+			redisTemplate.opsForValue().set(key, amount);
+		} catch (Exception e) {
+			log.error("송금 환불 실패 (트랜잭션 ID: {}): {}", senderId, e.getMessage());
+			throw e;
 		}
 	}
 
 
+	private void refundToSender(Transaction transaction) {
+		try {
+			String key = "transfer:" + transaction.getReceiverAccountId() + ":" + transaction.getSenderAccountId() + ":" + transaction.getAmount();
+			redisTemplate.opsForValue().set(key, transaction.getAmount());
+		} catch (Exception e) {
+			log.error("송금 환불 실패 (트랜잭션 ID: {}): {}", transaction.getId(), e.getMessage());
+			throw e;
+		}
+	}
 }
+
+

--- a/src/main/java/org/c4marathon/assignment/service/TransferScheduler.java
+++ b/src/main/java/org/c4marathon/assignment/service/TransferScheduler.java
@@ -22,7 +22,7 @@ public class TransferScheduler {
 	 * (1) 너무 짧은 주기로 실행할 경우 CPU 부하가 높아지도 레디스에도 부하가 많아진다.
 	 * 		=> 더 빨리 실시간 이체를 해야할 경우에는 메시지큐를 사용
 	 * **/
-	@Scheduled(fixedRate = 3000)
+	@Scheduled(fixedRate = 3000) //3초
 	public void completeTransfer() {
 		int batchSize = 1000;
 		String cursor = "0";

--- a/src/main/java/org/c4marathon/assignment/service/TransferService.java
+++ b/src/main/java/org/c4marathon/assignment/service/TransferService.java
@@ -23,7 +23,7 @@ public class TransferService {
 
 	@Transactional(isolation = Isolation.READ_COMMITTED)
 	public void transferBatch(List<String> keys) {
-		for (String key : keys) {
+		for (String key : keys) { //TransferScheduler에서 batch 사이즈 만큼 keys를 넘겨줌
 			try {
 				String[] parts = key.split(":");
 				long receiverAccountId = Long.parseLong(parts[2]);

--- a/src/main/java/org/c4marathon/assignment/service/UserService.java
+++ b/src/main/java/org/c4marathon/assignment/service/UserService.java
@@ -1,5 +1,7 @@
 package org.c4marathon.assignment.service;
 
+import org.c4marathon.assignment.common.exception.NotFoundException;
+import org.c4marathon.assignment.common.exception.enums.ErrorCode;
 import org.c4marathon.assignment.domain.User;
 import org.c4marathon.assignment.dto.request.SignUpRequestDto;
 import org.c4marathon.assignment.repository.UserRepository;
@@ -16,8 +18,13 @@ public class UserService {
 
 	@Transactional
 	public void signUp(SignUpRequestDto requestDto){
-		User user = new User(requestDto.username());
+		User user = new User(requestDto.username(), requestDto.email());
 		userRepository.save(user);
 		mainAccountService.createMainAccount(user);
 	}
+
+	public User getUser(long userId){
+		return userRepository.findById(userId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_USER));
+	}
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,7 @@ spring:
     properties:
       hibernate:
         format_sql: false
+        default_batch_fetch_size: 100
         use_sql_comments: false
         dialect: org.hibernate.dialect.MySQLDialect
   data:
@@ -21,3 +22,16 @@ spring:
       port: 6379
       password: ${REDIS_PASSWORD}
       timeout: 2000
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${GMAIL_ADDRESS}
+    password: ${GMAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          timeout: 5000
+          starttls:
+            enable: true


### PR DESCRIPTION
## 구현사항

1. 송금사용자의 설정에 따라 즉시 송금/ 대기후 수락 송금 방법으로 진행
    - 사용자의 설정값을 받아, Transaction DB에 저장후 바로 송금큐에 넣거나. Pending으로 상태값 변경
2. 송금 대기 걸기
3. 송금 72시간 limit 이 지나면 취소하기, 취소시 원래 금액 되돌리기
4. 송금 limit 24시간 남았을 때, 수령 리마인드 발송

## 프로그래밍 요구사항
1. 송금사용자의 설정에 따라 즉시 송금/ 대기후 수락 송금 방법으로 진행
    - Case를 나눠서 즉시 송금일 경우, 바로 받는 함수로 연결
    - Peding을 할 경우에는 내 계좌에서 돈을 빼고 Pending상태로 변환
2. 송금 대기 
    - transaction PENDING으로 상태값 변경
    - 송금을 받으라는 메일 전송 로직 연결
3. 송금 72시간 limit 이 지나면 취소하기
    - 취소의 경우에는 시간에 조금 민감하다는 생각이 들어 1분마다 스케줄러를 돌면서 수행
    - 커서 페이징을 통해서 1000개씩, 쿼리 조회
    - 쿼리 조회 조건은 transaction이 PENDING이며, PENDINGDate가 72시간이 지났으면 조회
    - 취소 후에는 transaction 상태값 변경후 환불 송금 진행(송금 큐에 넣기, 기존 함수 사용)
4. 송금 limit 24시간 남았을 때, 수령 리마인드 발송
    - 알림은 시간에 조금 덜 예민하다는 생각이들어 부하를 줄이고자... 5분마다 스케줄러를 돌면서 수행 
    - 위와 동일하게 커서페이징 1000개씩, 쿼리 조회
    - 쿼리 조회 조건은 transaction이 PENDING이며, PENDINGDate가 24시간 이내로 남았으며, 24시간 알림 메일이 안보내 진 것을 조회한다. 
    - 메일을 보내고 나서는 mailSent = true로 변경 

## 미완성 부분
1. 송금 대기 요청 수락(돈받기)
2. PENDING으로 정산할 경우, 내 계좌에서 돈을 미리 빼기 (기존의 돈이 부족한지 파악하고, 부족하다면 충전하는 로직 그대로 사용)
3. 실제로 제대로 동작하는지 테스트 전. (위의 함수 구현 후에 테스트 예정)

## 개선사항
1. 송금/이체 레디스큐를 Stream으로 변환 작업 ( 이부분에서 시간이 계속..오래 걸리네요.. 어렵다..)
2. 송금 로직을 하나로 합쳐서 똑같은 로직을 분산해서 사용하지 않도록 수정
4. SettlementService 로직 분리 
5. Transaction 부분 견고하게 롤백 설계, 전송 실패 시에 대한 보완할 부분 추가 
6. 코드 스멜 제거 (현재 깔끔하게 정리하지 못했습니다! Stream으로 변환하면서 정리하겠습니다)
